### PR TITLE
Adds new scrolling behavior to the TrainNodeCache

### DIFF
--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -538,8 +538,6 @@ TEST_F(FindManyTrainTestBase, PrefetchTest) {
 }
 
 
-
-
 TEST_F(FindManyTrainTestBase, ScrollToTest) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
   b->data()->reset(3, false, OLCBUSER);
@@ -610,5 +608,21 @@ TEST_F(FindManyTrainTestBase, ScrollToTest) {
   // After the wait for search we should have complete data.
   EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 20)));
 }  
+
+TEST_F(FindManyTrainTestBase, ScrollToTestEmpty) {
+  auto b = get_buffer_deleter(remoteClient_.alloc());
+  b->data()->reset(831, false, OLCBUSER);
+
+  expect_any_packet();
+  trainCache_.reset_search(std::move(b), &mockNotifiable_);
+  EXPECT_CALL(mockNotifiable_, notify()).Times(AtLeast(1));
+  wait_for_search();
+  EXPECT_EQ(0u, get_results_map().size());
+  EXPECT_EQ(0u, trainCache_.num_results());
+  
+  EXPECT_EQ(0 + trainCache_.FLAGS_TARGET_NOT_FOUND, trainCache_.scroll_to(0, 4, 2));
+  EXPECT_EQ(0u, get_results_map().size());
+  EXPECT_EQ(0u, trainCache_.num_results());
+}
 
 } // namespace commandstation

--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -433,7 +433,7 @@ TEST_F(FindManyTrainTestBase, BidirScrollWithPage) {
   wait_for_search();
   clear_expect(true);
 
-  LOG(INFO, "30");
+  LOG(INFO, "30, [%012" PRIx64 ",%012" PRIx64 "]", get_clip_min(), get_clip_max());
 
   EXPECT_EQ("TT 3000", get_results_map().begin()->second->name_);
   EXPECT_THAT(get_output(), ElementsAre("TT 3009", "TT 3010", "TT 3011"));

--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -465,4 +465,67 @@ TEST_F(FindManyTrainTestBase, BidirScrollWithPage) {
   clear_expect(true);
 }
 
+TEST_F(FindManyTrainTestBase, PrefetchTest) {
+  auto b = get_buffer_deleter(remoteClient_.alloc());
+  b->data()->reset(3, false, OLCBUSER);
+
+  expect_any_packet();
+  trainCache_.reset_search(std::move(b), &mockNotifiable_);
+  EXPECT_CALL(mockNotifiable_, notify()).Times(AtLeast(1));
+  wait_for_search();
+  EXPECT_EQ(16u, get_results_map().size());
+  EXPECT_EQ(25u, trainCache_.num_results());
+
+  vector<string> names;
+  for (int i = 0; i < 25; ++i) {
+    names.push_back(StringPrintf("TT %d", 3000 + i));
+  }
+  
+  EXPECT_THAT(get_output(), ElementsAre(names[0], names[1], names[2]));
+
+  for (int i = 0; i <= 22; ++i) {
+    EXPECT_THAT(get_output(), ElementsAre(names[i+0], names[i+1], names[i+2]));
+
+    LOG(INFO, "Round %d", i);
+    clear_expect(true);
+    if (i == 9 || i == 15) {
+      EXPECT_CALL(canBus_, mwrite(_)).Times(AtLeast(40));
+    }
+    trainCache_.scroll_down();
+    wait_for_search();
+    clear_expect(true);
+    if (i < 9) {
+      EXPECT_EQ(names[0], get_results_map().begin()->second->name_);
+    } else if (i < 15) {
+      EXPECT_EQ(names[6], get_results_map().begin()->second->name_);
+    } else if (i < 25) {
+      // 16 entries 3009..3024
+      EXPECT_EQ(names[9], get_results_map().begin()->second->name_);
+    }
+  }
+  
+  // at the peak the output is 22, 23, 24.
+  
+  // let's go backwards
+  for (int i = 22; i > 0; --i) {
+    EXPECT_THAT(get_output(), ElementsAre(names[i+0], names[i+1], names[i+2]));
+
+    LOG(INFO, "Round %d", i);
+    clear_expect(true);
+    if (i == 13 || i == 7) {
+      EXPECT_CALL(canBus_, mwrite(_)).Times(AtLeast(40));
+    }
+    trainCache_.scroll_up();
+    wait_for_search();
+    clear_expect(true);
+    if (i > 13) {
+      EXPECT_EQ(names[9], get_results_map().begin()->second->name_);
+    } else if (i > 7) {
+      EXPECT_EQ(names[3], get_results_map().begin()->second->name_);
+    } else {
+      EXPECT_EQ(names[0], get_results_map().begin()->second->name_);
+    } 
+  }
+}
+
 } // namespace commandstation

--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -607,8 +607,8 @@ TEST_F(FindManyTrainTestBase, ScrollToTest) {
   EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 18)));
   wait_for_search();
   clear_expect(true);
-  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 18)));
-  
+  // After the wait for search we should have complete data.
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 20)));
 }  
 
 } // namespace commandstation

--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -5,6 +5,7 @@
 #include "commandstation/TrainNodeInfoCache.hxx"
 
 using ::testing::ElementsAre;
+using ::testing::ContainerEq;
 
 namespace commandstation {
 
@@ -102,6 +103,14 @@ class FindManyTrainTestBase : public TrainDbTest {
       usleep(20000);
     }
     wait();
+  }
+
+  /// @return a subset of the names vector. first and last are indexes to the
+  /// base vector, both interpreted as inclusive.
+  vector<string> get_names_list(const vector<string>& base, int first,
+                                int last) {
+    vector<string> result(base.begin() + first, base.begin() + last + 1);
+    return result;
   }
 
   using NodeCacheMap = TrainNodeInfoCache::NodeCacheMap;
@@ -527,5 +536,79 @@ TEST_F(FindManyTrainTestBase, PrefetchTest) {
     } 
   }
 }
+
+
+
+
+TEST_F(FindManyTrainTestBase, ScrollToTest) {
+  auto b = get_buffer_deleter(remoteClient_.alloc());
+  b->data()->reset(3, false, OLCBUSER);
+
+  expect_any_packet();
+  trainCache_.reset_search(std::move(b), &mockNotifiable_);
+  EXPECT_CALL(mockNotifiable_, notify()).Times(AtLeast(1));
+  wait_for_search();
+  EXPECT_EQ(16u, get_results_map().size());
+  EXPECT_EQ(25u, trainCache_.num_results());
+  
+  vector<string> names;
+  vector<openlcb::NodeID> ids;
+  for (int i = 0; i < 25; ++i) {
+    names.push_back(StringPrintf("TT %d", 3000 + i));
+    ids.push_back(0x060100000000ULL | (3000 + i));
+  }
+
+  // This is the result of the initial search.
+  /// @todo we need to have the initial search also have the sizes specified.
+  EXPECT_THAT(get_output(), ElementsAre(names[0], names[1], names[2]));
+
+  LOG(INFO, "Initial scrolls");
+  // We scroll around a bit the existing cache contents.
+  clear_expect(true);
+  trainCache_.scroll_to(ids[0], 3, 3);
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 0, 3)));
+  clear_expect(true);
+
+  trainCache_.scroll_to(ids[5], 3, 3);
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 2, 8)));
+  clear_expect(true);
+
+  trainCache_.scroll_to(ids[5], 4, 2);
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 1, 7)));
+  clear_expect(true);
+
+  // Scroll barely to the border. 4 entries spare, no resync needed.
+  LOG(INFO, "Scroll to border");
+  clear_expect(true);
+  EXPECT_EQ(names[15], (--get_results_map().end())->second->name_);
+  EXPECT_EQ(0, trainCache_.scroll_to(ids[10], 4, 1));
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 6, 11)));
+  wait_for_search();
+  clear_expect(true);
+  
+  EXPECT_EQ(0, trainCache_.scroll_to(ids[1], 4, 1));
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 0, 2)));
+
+  // Scroll to the border with refresh.
+  clear_expect(true);
+  LOG(INFO, "Scroll to border with refresh");
+  EXPECT_CALL(canBus_, mwrite(_)).Times(AtLeast(40));
+  EXPECT_EQ((unsigned)trainCache_.FLAGS_NEED_REFILL_CACHE, trainCache_.scroll_to(ids[11], 4, 1));
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 7, 12)));
+  wait_for_search();
+  clear_expect(true);
+  EXPECT_EQ(names[3], get_results_map().begin()->second->name_);
+  EXPECT_EQ(names[18], (--get_results_map().end())->second->name_);
+
+  // Scroll to border with clip.
+  LOG(INFO, "Scroll to border with clip");
+  EXPECT_CALL(canBus_, mwrite(_)).Times(AtLeast(40));
+  EXPECT_EQ(trainCache_.FLAGS_NEED_REFILL_CACHE | trainCache_.FLAGS_CLIPPED_AT_BOTTOM, trainCache_.scroll_to(ids[18], 4, 2));
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 18)));
+  wait_for_search();
+  clear_expect(true);
+  EXPECT_THAT(get_output(), ContainerEq(get_names_list(names, 14, 18)));
+  
+}  
 
 } // namespace commandstation

--- a/cs/commandstation/TrainNodeInfoCache.hxx
+++ b/cs/commandstation/TrainNodeInfoCache.hxx
@@ -145,7 +145,7 @@ class TrainNodeInfoCache : public StateFlowBase {
       // TODO: maybe we need to add a pending search here?
       return false;
     }
-    scroll_to(id, 0, nodesToShow_);
+    scroll_to(id, 0, nodesToShow_ - 1);
     return true;
   }
 
@@ -158,7 +158,7 @@ class TrainNodeInfoCache : public StateFlowBase {
       return false;
     }
     // New scrolling implementation in compatibility mode.
-    scroll_to(it->first, 0, nodesToShow_);
+    scroll_to(it->first, 0, nodesToShow_ - 1);
     return true;
   }
 
@@ -224,7 +224,7 @@ class TrainNodeInfoCache : public StateFlowBase {
     }
     // Look around towards the bottom.
     auto itb = it;
-    if (!try_move_iterator(+resultsAfterTarget_, itb)) {
+    if (!try_move_iterator(+resultsAfterTarget_ + 1, itb)) {
       // ran out of results on the bottom.
       if (trainNodes_.resultsClippedAtBottom_) {
         // we should have a loading line now.

--- a/cs/commandstation/TrainNodeInfoCache.hxx
+++ b/cs/commandstation/TrainNodeInfoCache.hxx
@@ -234,7 +234,7 @@ class TrainNodeInfoCache : public StateFlowBase {
       // Found enough results downwards. Do we have enough left in the cache
       // though?
       auto itp = itb;
-      if (try_move_iterator(+scrollPrefetchSize_ - 1, itp)) {
+      if (try_move_iterator(+scrollPrefetchSize_, itp)) {
         // if we need to refill for the top, we should start from this node.
         refill_max_node = (--itp)->first;
       } else {

--- a/cs/commandstation/TrainNodeInfoCache.hxx
+++ b/cs/commandstation/TrainNodeInfoCache.hxx
@@ -234,7 +234,7 @@ class TrainNodeInfoCache : public StateFlowBase {
       // Found enough results downwards. Do we have enough left in the cache
       // though?
       auto itp = itb;
-      if (try_move_iterator(+scrollPrefetchSize_, itp)) {
+      if (try_move_iterator(+scrollPrefetchSize_ - 1, itp)) {
         // if we need to refill for the top, we should start from this node.
         refill_max_node = itp->first;
       } else {

--- a/cs/commandstation/TrainNodeInfoCache.hxx
+++ b/cs/commandstation/TrainNodeInfoCache.hxx
@@ -646,7 +646,7 @@ class TrainNodeInfoCache : public StateFlowBase {
       topNodeId_ = itt->first;
     } else {
       LOG(VERBOSE, "itt = empty");
-      // the resultset if probably empty
+      // the resultset is probably empty
       topNodeId_ = 0;
     }
     // Look around towards the bottom.

--- a/cs/commandstation/TrainNodeInfoCache.hxx
+++ b/cs/commandstation/TrainNodeInfoCache.hxx
@@ -234,9 +234,9 @@ class TrainNodeInfoCache : public StateFlowBase {
       // Found enough results downwards. Do we have enough left in the cache
       // though?
       auto itp = itb;
-      if (try_move_iterator(+scrollPrefetchSize_ - 1, itp)) {
+      if (try_move_iterator(+scrollPrefetchSize_, itp)) {
         // if we need to refill for the top, we should start from this node.
-        refill_max_node = itp->first;
+        refill_max_node = (--itp)->first;
       } else {
         if (trainNodes_.resultsClippedAtBottom_) {
           flags |= FLAGS_NEED_REFILL_CACHE;

--- a/cs/commandstation/traindb_test_utils.hxx
+++ b/cs/commandstation/traindb_test_utils.hxx
@@ -48,9 +48,13 @@ class TrainDbTestBase : public openlcb::TractionTest {
 
 class TrainDbTest : public TrainDbTestBase {
  protected:
-  TrainDbTest() { wait(); }
+  TrainDbTest() {
+    startupBlock_.release_block();
+    wait();
+  }
   ~TrainDbTest() { wait(); }
 
+  BlockExecutor startupBlock_{&g_executor};
   openlcb::CanDatagramService dgHandler_{ifCan_.get(), 5, 2};
   openlcb::MemoryConfigHandler memCfgHandler_{&dgHandler_, node_, 5};
   openlcb::SimpleInfoFlow infoFlow_{&g_service};


### PR DESCRIPTION
This scrolling behavior allows centering around a line instead of marking the top line for a page.