### PR TITLE
Explicit trainDB size

### DIFF
--- a/cs/commandstation/TrainDbCdi.hxx
+++ b/cs/commandstation/TrainDbCdi.hxx
@@ -35,17 +35,18 @@
 #ifndef _BRACZ_COMMANDSTATION_TRAINDBCDI_HXX_
 #define _BRACZ_COMMANDSTATION_TRAINDBCDI_HXX_
 
+#include "ConfigLocal.hxx"
+
 #include "openlcb/ConfigRepresentation.hxx"
 #include "openlcb/TractionCvCdi.hxx"
 #include "commandstation/TrainDbDefs.hxx"
 
 namespace commandstation {
 
-#ifdef TRAINDB_TRAIN_COUNT
-static constexpr unsigned STORED_TRAIN_COUNT = TRAINDB_TRAIN_COUNT;
-#else
-static constexpr unsigned STORED_TRAIN_COUNT = 32;
+#ifndef TRAINDB_TRAIN_COUNT
+#error must define TRAINDB_TRAIN_COUNT in your headers
 #endif
+static constexpr unsigned STORED_TRAIN_COUNT = TRAINDB_TRAIN_COUNT;
 
 static const char MOMENTARY_MAP[] =
     "<relation><property>0</property><value>Latching</value></relation>"


### PR DESCRIPTION
Makes the TrainDB size explicitly configured by every target. This avoids problems when two different compilation units accidentally build with different trainDB sizes, at the expense of a bunch of one-time compilation errors during the transition.
