### PR TITLE
Sends ESTOP messages before track off

### DIFF
--- a/cs/commandstation/TrackPowerBit.cxxtest
+++ b/cs/commandstation/TrackPowerBit.cxxtest
@@ -2,32 +2,21 @@
 #include "commandstation/track_test_helper.hxx"
 #include "utils/Singleton.hxx"
 
-
 class MockDccControl : public Singleton<MockDccControl> {
-public:
+ public:
   MOCK_METHOD0(query_dcc, bool());
   MOCK_METHOD0(enable_dcc, void());
   MOCK_METHOD0(disable_dcc, void());
 };
 
-bool query_dcc() {
-  return Singleton<MockDccControl>::instance()->query_dcc();
-}
+bool query_dcc() { return Singleton<MockDccControl>::instance()->query_dcc(); }
 
-void enable_dcc() {
-  Singleton<MockDccControl>::instance()->enable_dcc();
-}
+void enable_dcc() { Singleton<MockDccControl>::instance()->enable_dcc(); }
 
-void disable_dcc() {
-  Singleton<MockDccControl>::instance()->disable_dcc();
-}
+void disable_dcc() { Singleton<MockDccControl>::instance()->disable_dcc(); }
 
 namespace commandstation {
 namespace {
-
-
-
-
 
 class TrackPowerTest : public UpdateProcessorTest {
  protected:
@@ -58,8 +47,8 @@ TEST_F(TrackPowerTest, disable_no_packet) {
 }
 
 TEST_F(TrackPowerTest, disable_estop_packets) {
-  EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF)))).Times(4);
+  EXPECT_CALL(trackSendQueue_, arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF))))
+      .Times(4);
   for (int i = 0; i < 4; ++i) {
     send_empty_packet();
   }
@@ -68,9 +57,10 @@ TEST_F(TrackPowerTest, disable_estop_packets) {
   wait();
   Mock::VerifyAndClear(&mockDcc_);
   EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2)))).Times(10);
-  EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0)))).Times(10);
+              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2))))
+      .Times(10);
+  EXPECT_CALL(trackSendQueue_, arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0))))
+      .Times(10);
   for (int i = 0; i < 19; ++i) {
     send_empty_packet();
   }
@@ -81,9 +71,10 @@ TEST_F(TrackPowerTest, disable_estop_packets) {
   Mock::VerifyAndClear(&mockDcc_);
   // after disabling dcc we are still getting estop packets.
   EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2)))).Times(2);
-  EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0)))).Times(2);
+              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2))))
+      .Times(2);
+  EXPECT_CALL(trackSendQueue_, arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0))))
+      .Times(2);
   for (int i = 0; i < 4; ++i) {
     send_empty_packet();
   }
@@ -93,8 +84,8 @@ TEST_F(TrackPowerTest, disable_estop_packets) {
   EXPECT_CALL(mockDcc_, enable_dcc());
   send_packet(":X195B4123N010000000000FFFE;");
   qwait();
-  EXPECT_CALL(trackSendQueue_,
-              arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF)))).Times(4);
+  EXPECT_CALL(trackSendQueue_, arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF))))
+      .Times(4);
   for (int i = 0; i < 4; ++i) {
     send_empty_packet();
   }
@@ -119,6 +110,6 @@ TEST_F(TrackPowerTest, query) {
                                   ":X194C522AN010000000000FFFE;");
   qwait();
 }
-  
-} // namespace
-} // namespace commandstation
+
+}  // namespace
+}  // namespace commandstation

--- a/cs/commandstation/TrackPowerBit.cxxtest
+++ b/cs/commandstation/TrackPowerBit.cxxtest
@@ -1,0 +1,124 @@
+#include "commandstation/TrackPowerBit.hxx"
+#include "commandstation/track_test_helper.hxx"
+#include "utils/Singleton.hxx"
+
+
+class MockDccControl : public Singleton<MockDccControl> {
+public:
+  MOCK_METHOD0(query_dcc, bool());
+  MOCK_METHOD0(enable_dcc, void());
+  MOCK_METHOD0(disable_dcc, void());
+};
+
+bool query_dcc() {
+  return Singleton<MockDccControl>::instance()->query_dcc();
+}
+
+void enable_dcc() {
+  Singleton<MockDccControl>::instance()->enable_dcc();
+}
+
+void disable_dcc() {
+  Singleton<MockDccControl>::instance()->disable_dcc();
+}
+
+namespace commandstation {
+namespace {
+
+
+
+
+
+class TrackPowerTest : public UpdateProcessorTest {
+ protected:
+  StrictMock<MockDccControl> mockDcc_;
+  TrackPowerBit powerBit_{node_,
+                          openlcb::TractionDefs::CLEAR_EMERGENCY_STOP_EVENT,
+                          openlcb::TractionDefs::EMERGENCY_STOP_EVENT};
+  openlcb::BitEventConsumer powerC_{&powerBit_};
+};
+
+TEST_F(TrackPowerTest, create) {
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF))));
+  send_empty_packet();
+  qwait();
+}
+
+TEST_F(TrackPowerTest, enable) {
+  EXPECT_CALL(mockDcc_, enable_dcc());
+  send_packet(":X195B4123N010000000000FFFE;");
+  wait();
+}
+
+TEST_F(TrackPowerTest, disable_no_packet) {
+  send_packet(":X195B4123N010000000000FFFF;");
+  wait();
+  Mock::VerifyAndClear(&mockDcc_);
+}
+
+TEST_F(TrackPowerTest, disable_estop_packets) {
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF)))).Times(4);
+  for (int i = 0; i < 4; ++i) {
+    send_empty_packet();
+  }
+  qwait();
+  send_packet(":X195B4123N010000000000FFFF;");
+  wait();
+  Mock::VerifyAndClear(&mockDcc_);
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2)))).Times(10);
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0)))).Times(10);
+  for (int i = 0; i < 19; ++i) {
+    send_empty_packet();
+  }
+  wait();
+  EXPECT_CALL(mockDcc_, disable_dcc());
+  send_empty_packet();
+  wait();
+  Mock::VerifyAndClear(&mockDcc_);
+  // after disabling dcc we are still getting estop packets.
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x4, dcc_from(0, 0b01100001, -2)))).Times(2);
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x66, dcc_from(0, 0, 0xC0)))).Times(2);
+  for (int i = 0; i < 4; ++i) {
+    send_empty_packet();
+  }
+  wait();
+
+  // After reenable we'll get idle packets.
+  EXPECT_CALL(mockDcc_, enable_dcc());
+  send_packet(":X195B4123N010000000000FFFE;");
+  qwait();
+  EXPECT_CALL(trackSendQueue_,
+              arrived(PacketIs(0x04, dcc_from(0xFF, 0, 0xFF)))).Times(4);
+  for (int i = 0; i < 4; ++i) {
+    send_empty_packet();
+  }
+  qwait();
+}
+
+TEST_F(TrackPowerTest, query) {
+  EXPECT_CALL(mockDcc_, query_dcc()).WillOnce(Return(true));
+  send_packet_and_expect_response(":X198F4123N010000000000FFFF;",
+                                  ":X194C522AN010000000000FFFF;");
+  qwait();
+  EXPECT_CALL(mockDcc_, query_dcc()).WillOnce(Return(true));
+  send_packet_and_expect_response(":X198F4123N010000000000FFFE;",
+                                  ":X194C422AN010000000000FFFE;");
+  qwait();
+  EXPECT_CALL(mockDcc_, query_dcc()).WillOnce(Return(false));
+  send_packet_and_expect_response(":X198F4123N010000000000FFFF;",
+                                  ":X194C422AN010000000000FFFF;");
+  qwait();
+  EXPECT_CALL(mockDcc_, query_dcc()).WillOnce(Return(false));
+  send_packet_and_expect_response(":X198F4123N010000000000FFFE;",
+                                  ":X194C522AN010000000000FFFE;");
+  qwait();
+}
+  
+} // namespace
+} // namespace commandstation

--- a/cs/commandstation/UpdateProcessor.cxxtest
+++ b/cs/commandstation/UpdateProcessor.cxxtest
@@ -1,52 +1,4 @@
-#include "utils/async_if_test_helper.hxx"
-
-#include "commandstation/UpdateProcessor.hxx"
-#include "dcc/Loco.hxx"
-#include "dcc/UpdateLoop.hxx"
-
-#include "dcc/dcc_test_utils.hxx"
-
-using ::testing::ElementsAre;
-
-class MockPacketQueue : public dcc::PacketFlowInterface {
- public:
-  MOCK_METHOD1(arrived, void(const dcc::Packet&));
-
-  void send(Buffer<dcc::Packet>* b, unsigned prio) {
-    dcc::Packet* pkt = b->data();
-    arrived(*pkt);
-    b->unref();
-  }
-};
-
-OVERRIDE_CONST(dcc_packet_min_refresh_delay_ms, 50);
-
-class UpdateProcessorTest : public AsyncCanTest {
- protected:
-  UpdateProcessorTest() : updateProcessor_(&g_service, &trackSendQueue_) {}
-
-  ~UpdateProcessorTest() { wait(); }
-
-  void send_empty_packet() {
-    Buffer<dcc::Packet>* b;
-    mainBufferPool->alloc(&b, nullptr);
-    updateProcessor_.send(b);
-  }
-
-  void wait() {
-    usleep(70000);
-    AsyncCanTest::wait();
-    Mock::VerifyAndClear(&updateProcessor_);
-  }
-
-  void qwait() {
-    AsyncCanTest::wait();
-    Mock::VerifyAndClear(&updateProcessor_);
-  }
-
-  StrictMock<MockPacketQueue> trackSendQueue_;
-  commandstation::UpdateProcessor updateProcessor_;
-};
+#include "commandstation/track_test_helper.hxx"
 
 TEST_F(UpdateProcessorTest, CreateDestroy) {}
 
@@ -231,24 +183,15 @@ TEST_F(UpdateProcessorTest, OneTrainRefreshAndUpdate) {
 
 using dcc::SpeedType;
 
-class ExclusiveSource : public dcc::PacketSource {
+class ExclusiveSource : public dcc::NonTrainPacketSource {
  public:
   void get_next_packet(unsigned code, dcc::Packet* packet) override {
     packet->set_dcc_speed14(dcc::DccShortAddress(0), true, false,
                             dcc::Packet::EMERGENCY_STOP);
   }
-  void set_speed(SpeedType speed) override {}
-  SpeedType get_speed() override { return SpeedType(); }
-  void set_emergencystop() override {}
-  void set_fn(uint32_t address, uint16_t value) override {}
-  uint16_t get_fn(uint32_t address) override { return 0; }
-  uint32_t legacy_address() override { return 0; }
-  dcc::TrainAddressType legacy_address_type() override {
-    return dcc::TrainAddressType::DCC_SHORT_ADDRESS;
-  }
 } exclusive_source;
 
-class SecondExclusiveSource : public ExclusiveSource {
+class SecondExclusiveSource : public dcc::NonTrainPacketSource {
  public:
   void get_next_packet(unsigned code, dcc::Packet* packet) override {
     packet->set_dcc_speed14(dcc::DccShortAddress(13), true, false, 0);

--- a/cs/commandstation/track_test_helper.hxx
+++ b/cs/commandstation/track_test_helper.hxx
@@ -21,7 +21,7 @@ class MockPacketQueue : public dcc::PacketFlowInterface {
 
 OVERRIDE_CONST(dcc_packet_min_refresh_delay_ms, 50);
 
-class UpdateProcessorTest : public AsyncCanTest {
+class UpdateProcessorTest : public openlcb::AsyncNodeTest {
  protected:
   UpdateProcessorTest() : updateProcessor_(&g_service, &trackSendQueue_) {}
 

--- a/cs/commandstation/track_test_helper.hxx
+++ b/cs/commandstation/track_test_helper.hxx
@@ -1,0 +1,49 @@
+#include "utils/async_if_test_helper.hxx"
+
+#include "commandstation/UpdateProcessor.hxx"
+#include "dcc/Loco.hxx"
+#include "dcc/UpdateLoop.hxx"
+
+#include "dcc/dcc_test_utils.hxx"
+
+using ::testing::ElementsAre;
+
+class MockPacketQueue : public dcc::PacketFlowInterface {
+ public:
+  MOCK_METHOD1(arrived, void(const dcc::Packet&));
+
+  void send(Buffer<dcc::Packet>* b, unsigned prio) {
+    dcc::Packet* pkt = b->data();
+    arrived(*pkt);
+    b->unref();
+  }
+};
+
+OVERRIDE_CONST(dcc_packet_min_refresh_delay_ms, 50);
+
+class UpdateProcessorTest : public AsyncCanTest {
+ protected:
+  UpdateProcessorTest() : updateProcessor_(&g_service, &trackSendQueue_) {}
+
+  ~UpdateProcessorTest() { wait(); }
+
+  void send_empty_packet() {
+    Buffer<dcc::Packet>* b;
+    mainBufferPool->alloc(&b, nullptr);
+    updateProcessor_.send(b);
+  }
+
+  void wait() {
+    usleep(70000);
+    AsyncCanTest::wait();
+    Mock::VerifyAndClear(&updateProcessor_);
+  }
+
+  void qwait() {
+    AsyncCanTest::wait();
+    Mock::VerifyAndClear(&updateProcessor_);
+  }
+
+  StrictMock<MockPacketQueue> trackSendQueue_;
+  commandstation::UpdateProcessor updateProcessor_;
+};


### PR DESCRIPTION
Updates TrackPowerBit consumer to disable DCC packet refresh and send ESTOP messages to the track when the estop button is pressed.