### PR TITLE
Service mode programming frontend

### DIFF
--- a/cs/commandstation/ProgrammingTrackCVSpace.hxx
+++ b/cs/commandstation/ProgrammingTrackCVSpace.hxx
@@ -82,6 +82,13 @@ class ProgrammingTrackCVSpace : private openlcb::MemorySpace,
     switch(destination) {
       case cfg.value().offset():
         return eval_async_state(STATE(do_cv_write), again, error, len);
+      case cfg.advanced().repeat_verify().offset():
+        frontend_->set_repeat_verify(be32toh(store_.verify_repeats));
+        break;
+      case cfg.advanced().repeat_cooldown_reset().offset():
+        frontend_->set_repeat_verify_cooldown(
+            be32toh(store_.verify_cooldown_repeats));
+        break;
     }
     return len;
   }

--- a/cs/commandstation/ProgrammingTrackCVSpace.hxx
+++ b/cs/commandstation/ProgrammingTrackCVSpace.hxx
@@ -1,0 +1,210 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are strictly prohibited without written consent.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file ProgrammingTrackCVSpace.hxx
+ *
+ * CV space to access the programming track flow.
+ *
+ * @author Balazs Racz
+ * @date 2 June 2018
+ */
+
+#ifndef _COMMANDSTATION_PROGRAMMINGTRACKCVSPACE_HXX_
+#define _COMMANDSTATION_PROGRAMMINGTRACKCVSPACE_HXX_
+
+#include "commandstation/ProgrammingTrackFrontend.hxx"
+#include "commandstation/ProgrammingTrackSpaceConfig.hxx"
+#include "utils/ConfigUpdateListener.hxx"
+#include "openlcb/MemoryConfig.hxx"
+
+namespace commandstation {
+
+class ProgrammingTrackCVSpace : private openlcb::MemorySpace,
+                                private DefaultConfigUpdateListener,
+                                public StateFlowBase {
+ public:
+  ProgrammingTrackCVSpace(openlcb::MemoryConfigHandler* parent,
+                          ProgrammingTrackFrontend* frontend,
+                          openlcb::Node* node)
+      : StateFlowBase(parent->service()),
+        parent_(parent),
+        frontend_(frontend),
+        node_(node) {
+    parent_->registry()->insert(node_, SPACE_ID, this);
+    memset(&store_, 0, sizeof(store_));
+  }
+
+  ~ProgrammingTrackCVSpace() {
+    parent_->registry()->erase(node_, SPACE_ID, this);
+  }
+
+  /// @returns whether the memory space does not accept writes.
+  bool read_only() override
+  {
+    return false;
+  }
+
+  address_t max_address() override {
+    return MAX_ADDRESS;
+  }
+
+  size_t write(address_t destination, const uint8_t *data, size_t len,
+               errorcode_t *error, Notifiable *again) override {
+    if (destination < MIN_ADDRESS || destination > MAX_ADDRESS) {
+      *error = openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+      return 0;
+    }
+    if (destination + len - 1 > MAX_ADDRESS) {
+      len = MAX_ADDRESS - destination + 1;
+    }
+    if ((destination + len) > ((destination & (~3)) + 4)) {
+      // Write goes across fields. Trim len.
+      len = ((destination & (~3)) + 4) - destination;
+    }
+    memcpy(((uint8_t*)&store_) + (destination - MIN_ADDRESS), data, len);
+    destination &= ~3;
+    switch(destination) {
+      case cfg.value().offset():
+        return eval_async_state(STATE(do_cv_write), again, error, len);
+    }
+    return len;
+  }
+  
+  size_t read(address_t source, uint8_t *dst, size_t len, errorcode_t *error,
+              Notifiable *again) override {
+    if (source < MIN_ADDRESS || source > MAX_ADDRESS) {
+      *error = openlcb::MemoryConfigDefs::ERROR_OUT_OF_BOUNDS;
+      return 0;
+    }
+    if (source + len - 1 > MAX_ADDRESS) {
+      len = MAX_ADDRESS - source + 1;
+    }
+    memcpy(dst, ((uint8_t*)&store_) + (source - MIN_ADDRESS), len);
+    if (len > 4 || (source & 3) || store_.mode == 0) {
+      // We do actual operations only if individual fields are requested.
+      return len;
+    }
+    switch(source) {
+      case cfg.value().offset():
+        return eval_async_state(STATE(do_cv_read), again, error, len);
+    }
+    return len;
+  }
+
+  
+ private:
+  void factory_reset(int fd) override {}
+  UpdateAction apply_configuration(int fd, bool initial_load,
+                                   BarrierNotifiable *done) override {
+    AutoNotify an(done);
+    // We reset the backing store to all zeros, causing the programming track
+    // to be disabled, when the user closes the JMRI configuration window. This
+    // will avoid reads causing spurious operations when the window is next
+    // opened.
+    memset(&store_, 0, sizeof(store_));
+    return UPDATED;
+  }
+
+  /// Helper function for calling async states from write() and read()
+  /// commands.
+  /// @param start_state is the state flow state to call to startthe async
+  /// processing.
+  /// @param done is the notifiable to call when async processing is completed
+  /// @param error is where to save the async processing error code
+  /// @param len is the return value when the read/write completed successfully.
+  /// @return what needs to be returned from the read/write virtual function.
+  size_t eval_async_state(Callback start_state, Notifiable* done, errorcode_t* error, size_t len) {
+    if (asyncState_ == DONE) {
+      asyncState_ = IDLE;
+      *error = asyncError_;
+      return len;
+    }
+    HASSERT(asyncState_ == IDLE);
+    HASSERT(is_terminated());
+    start_flow(start_state);
+    *error = ERROR_AGAIN;
+    done_ = done;
+    asyncState_ = PENDING;
+    asyncError_ = 0;
+    return 0;
+  }
+
+  Action do_cv_write() {
+    return finish_async_state(openlcb::Defs::ERROR_UNIMPLEMENTED);
+  }
+  
+  Action do_cv_read() {
+    return invoke_subflow_and_wait(
+        frontend_, STATE(cv_read_done),
+        ProgrammingTrackFrontendRequest::DIRECT_READ_BYTE, ntohl(store_.cv));
+  }
+
+  Action cv_read_done() {
+    auto b = get_buffer_deleter(full_allocation_result(frontend_));
+    store_.value = htobe32(b->data()->value_);
+    return finish_async_state(b->data()->resultCode);
+  }
+
+  /// Call this function form async processing states to stop the async state.
+  Action finish_async_state(unsigned error_code) {
+    asyncError_ = error_code;
+    asyncState_ = DONE;
+    done_->notify();
+    return exit();
+  }
+  
+  static constexpr unsigned SPACE_ID =
+      ProgrammingTrackSpaceConfig::group_opts().segment();
+  static constexpr unsigned MIN_ADDRESS =
+      ProgrammingTrackSpaceConfig::group_opts().get_segment_offset();
+  static constexpr unsigned MAX_ADDRESS =
+      ProgrammingTrackSpaceConfig::group_opts().get_segment_offset() +
+      ProgrammingTrackSpaceConfig::size() - 1;
+  static constexpr ProgrammingTrackSpaceConfig cfg{ProgrammingTrackSpaceConfig::group_opts().get_segment_offset()};
+
+  enum AsyncState {
+    IDLE = 0,
+    PENDING,
+    DONE
+  };
+
+  /// Where are we with doing asynchronous operations like read/write.
+  AsyncState asyncState_{IDLE};
+  /// Error return value from async state.
+  unsigned asyncError_;
+  /// Caller to notify when async state completes.
+  Notifiable* done_;
+  /// RAM backing store for the CDI variables. Note that everything here is
+  /// network-endian so reading and writing here needs to be done with endian
+  /// conversion routines.
+  ProgrammingTrackSpaceConfig::Shadow store_;
+
+  /// Handler to the memory config service
+  openlcb::MemoryConfigHandler* parent_;
+  /// Frontend to use to execute programming track commands.
+  ProgrammingTrackFrontend* frontend_;
+  /// Node to which the programming track is attached to.
+  openlcb::Node* node_;
+  /// Which memory space we exported ourselves.
+  uint8_t spaceId_;
+};
+
+}  // namespace commandstation
+
+#endif  // _COMMANDSTATION_PROGRAMMINGTRACKCVSPACE_HXX_

--- a/cs/commandstation/ProgrammingTrackFrontend.hxx
+++ b/cs/commandstation/ProgrammingTrackFrontend.hxx
@@ -1,0 +1,179 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are strictly prohibited without written consent.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file ProgrammingTrackFrontend.hxx
+ *
+ * Flow and CV space to access the programming track.
+ *
+ * @author Balazs Racz
+ * @date 1 June 2018
+ */
+
+#ifndef _COMMANDSTATON_PROGRAMMINGTRACKFRONTEND_HXX_
+#define _COMMANDSTATON_PROGRAMMINGTRACKFRONTEND_HXX_
+
+#include "executor/CallableFlow.hxx"
+#include "openlcb/MemoryConfig.hxx"
+#include "dcc/ProgrammingTrackBackend.hxx"
+
+namespace commandstation {
+
+struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
+  enum DirectWriteByte { DIRECT_WRITE_BYTE };
+  enum DirectWriteBit { DIRECT_WRITE_BIT };
+  enum DirectReadByte { DIRECT_READ_BYTE };
+  enum DirectReadBit { DIRECT_READ_BIT };
+
+  /// Request up to write a byte sized CV in direct mode.
+  /// @param cv_number is the 1-based CV number (as the user sees it).
+  /// @param value is the value to set the CV to.
+  void reset(DirectWriteByte, unsigned cv_number, uint8_t value) {
+    reset_base();
+    cmd_ = Type::DIRECT_WRITE_BYTE;
+    cvOffset_ = cv_number - 1;
+    value_ = value;
+  }
+
+  /// Request up to read a byte sized CV in direct mode.
+  /// @param cv_number is the 1-based CV number (as the user sees it).
+  void reset(DirectReadByte, unsigned cv_number) {
+    reset_base();
+    cmd_ = Type::DIRECT_READ_BYTE;
+    cvOffset_ = cv_number - 1;
+    value_ = 0;
+  }
+
+  /// Calues for the cmd_ argument.
+  enum class Type {
+    DIRECT_WRITE_BYTE,
+    DIRECT_WRITE_BIT,
+    DIRECT_READ_BYTE,
+    DIRECT_READ_BIT
+  };
+
+  /// What is the instruction to do.
+  Type cmd_;
+  /// 0-based CV number to read or write
+  unsigned cvOffset_;
+  /// input or output argument containing the byte or bit value read or
+  /// written.
+  uint8_t value_;
+};
+
+class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendRequest> {
+ public:
+  ProgrammingTrackFrontend(ProgrammingTrackBackend* backend)
+      : CallableFlow<ProgrammingTrackFrontendRequest>(backend->service()) {}
+
+  typedef ProgrammingTrackFrontendRequest::Type RequestType;
+
+  enum ResultCodes {
+    /// Success
+    ERROR_CODE_OK = openlcb::Defs::ERROR_CODE_OK,
+    /// Error code when the locomotive is not responding to programming track
+    /// requests. Usually dirty track or so.
+    ERROR_NO_LOCO = openlcb::Defs::ERROR_OPENLCB_TIMEOUT | 1,
+    /// Error code when something was invoked that is not implemented.
+    ERROR_UNIMPLEMENTED_CMD = openlcb::Defs::ERROR_UNIMPLEMENTED_CMD,
+    /// cleared when done is called.
+    OPERATION_PENDING = openlcb::DatagramClient::OPERATION_PENDING,
+  };
+
+  Action entry() override {
+    request()->resultCode = OPERATION_PENDING;
+    switch (request()->cmd_) {
+      case RequestType::DIRECT_WRITE_BYTE:
+      case RequestType::DIRECT_WRITE_BIT:
+      case RequestType::DIRECT_READ_BYTE:
+      case RequestType::DIRECT_READ_BIT:
+        return call_immediately(STATE(enter_service_mode));
+      default:
+        return return_with_error(ERROR_UNIMPLEMENTED_CMD);
+    }
+  }
+
+  Action enter_service_mode() {
+    return invoke_subflow_and_wait(backend_, STATE(send_initial_resets),
+                                   ProgrammingTrackRequest::ENTER_SERVICE_MODE);
+  }
+
+  Action send_initial_resets() {
+    auto b = get_buffer_deleter(full_allocation_result(backend_));
+    return invoke_subflow_and_wait(backend_, STATE(enter_service_mode_done),
+                                   ProgrammingTrackRequest::SEND_RESET, 15);
+  }
+
+  Action enter_service_mode_done() {
+    auto b = get_buffer_deleter(full_allocation_result(backend_));
+    switch (request()->cmd_) {
+      case RequestType::DIRECT_WRITE_BYTE:
+        serviceModePacket_.set_dcc_svc_write_byte(request()->cvOffset_,
+                                                  request()->value_);
+        break;
+      default:
+        // Bail out as we have not written this code yet.
+        request()->resultCode |= ERROR_UNIMPLEMENTED_CMD;
+        return invoke_subflow_and_wait(
+            backend_, STATE(return_response),
+            ProgrammingTrackRequest::EXIT_SERVICE_MODE);
+    }
+    return invoke_subflow_and_wait(
+        backend_, STATE(pkt_sent),
+        ProgrammingTrackRequest::SEND_PROGRAMMING_PACKET, serviceModePacket_,
+        3);
+  }
+
+  Action pkt_sent() {
+    auto b = get_buffer_deleter(full_allocation_result(backend_));
+    if (b->data()->hasAck_) {
+      // we're good
+      request()->resultCode |= ERROR_CODE_OK;
+    } else {
+      request()->resultCode |= ERROR_NO_LOCO;
+    }
+    // Cooldown for the decoder.
+    // 
+    // @todo: we need to instead create some form of timer for when to exit
+    // service mode. Consecutive operations should not exit and enter service
+    // mode separately.
+    return invoke_subflow_and_wait(backend_, STATE(cooldown_done),
+                                   ProgrammingTrackRequest::SEND_RESET, 15);
+    
+  }
+
+  Action cooldown_done() {
+    auto b = get_buffer_deleter(full_allocation_result(backend_));
+    return invoke_subflow_and_wait(
+        backend_, STATE(return_response),
+        ProgrammingTrackRequest::EXIT_SERVICE_MODE);
+  }
+  
+  Action return_response() {
+    auto b = get_buffer_deleter(full_allocation_result(backend_));
+    return return_with_error(request()->resultCode & (~OPERATION_PENDING));
+  }
+
+ private:
+  ProgrammingTrackBackend* backend_;
+  dcc::Packet serviceModePacket_;
+};
+
+}  // namespace commandstation
+
+#endif  // _COMMANDSTATON_PROGRAMMINGTRACKFRONTEND_HXX_

--- a/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
+++ b/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
@@ -66,7 +66,24 @@ enum OperatingMode {
 
 CDI_GROUP_ENTRY(mode, openlcb::Uint32ConfigEntry, Name("Operating mode"), MapValues(OPERATING_MODE_MAP_VALUES));
 CDI_GROUP_ENTRY(cv, openlcb::Uint32ConfigEntry, Name("CV number"), Description("Number of CV to read or write (1..1024)."), Default(0), Min(0), Max(1024));
-CDI_GROUP_ENTRY(value, openlcb::Uint32ConfigEntry, Name("CV value"), Description("Read or write this field to access the given CV."), Default(0), Min(0), Max(255));
+CDI_GROUP_ENTRY(
+    value, openlcb::Uint32ConfigEntry, Name("CV value"),
+    Description(
+        "Set 'Operating mode' and 'CV number' first, then: hit 'Refresh' to "
+        "read the entire CV, or enter a value and hit 'Write' to set the CV."),
+    Default(0), Min(0), Max(255));
+CDI_GROUP_ENTRY(
+    bit_write_value, openlcb::Uint32ConfigEntry, Name("Bit change"),
+    Description(
+        "Set 'Operating mode' and 'CV number' first, then: write 1064 to set "
+        "the single bit whose value is 64, or 2064 to clear that bit. Write "
+        "100 to 107 to set bit index 0 to 7, or 200 to 207 to clear bit 0 to "
+        "7. Values outside of these two ranges do nothing."),
+    Default(1000), Min(100), Max(2128));
+CDI_GROUP_ENTRY(bit_value_string, openlcb::StringConfigEntry<24>,
+                Name("Read bits decomposition"),
+                Description("Hit Refresh on this line after reading a CV value "
+                            "to see which bits are set."));
 CDI_GROUP_ENTRY(advanced, ProgrammingTrackSpaceConfigAdvanced,
                 Name("Advanced settings"));
 struct Shadow;
@@ -77,6 +94,8 @@ struct ProgrammingTrackSpaceConfig::Shadow {
   uint32_t mode;
   uint32_t cv;
   uint32_t value;
+  uint32_t bit_write_value;
+  char bit_value_string[24];
   uint32_t verify_repeats;
   uint32_t verify_cooldown_repeats;
 };
@@ -100,4 +119,3 @@ static_assert(SHADOW_OFFSETOF(verify_cooldown_repeats) ==
 
 
 #endif // _COMMANDSTATION_PROGRAMMINGTRACKSPACECONFIG_HXX_
-

--- a/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
+++ b/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
@@ -39,6 +39,20 @@ static const char OPERATING_MODE_MAP_VALUES[] = R"(
 )";
 
 
+CDI_GROUP(ProgrammingTrackSpaceConfigAdvanced);
+CDI_GROUP_ENTRY(
+    repeat_verify, openlcb::Uint32ConfigEntry,
+    Name("Repeat count for verify packets"),
+    Description("How many times a direct mode bit verify packet needs to be "
+                "repeated for an acknowledgement to be generated."),
+    Default(3), Min(0), Max(255));
+CDI_GROUP_ENTRY(
+    repeat_cooldown_reset, openlcb::Uint32ConfigEntry,
+    Name("Repeat count for reset packets after verify"),
+    Description("How many reset packets to send after a verify."),
+    Default(6), Min(0), Max(255));
+CDI_GROUP_END();
+
 CDI_GROUP(ProgrammingTrackSpaceConfig, Segment(0x15), Offset(0x7F100000),
           Name("Programming track operation"),
           Description("Use this component to read and write CVs on the "
@@ -53,6 +67,8 @@ enum OperatingMode {
 CDI_GROUP_ENTRY(mode, openlcb::Uint32ConfigEntry, Name("Operating mode"), MapValues(OPERATING_MODE_MAP_VALUES));
 CDI_GROUP_ENTRY(cv, openlcb::Uint32ConfigEntry, Name("CV number"), Description("Number of CV to read or write (1..1024)."), Default(0), Min(0), Max(1024));
 CDI_GROUP_ENTRY(value, openlcb::Uint32ConfigEntry, Name("CV value"), Description("Read or write this field to access the given CV."), Default(0), Min(0), Max(255));
+CDI_GROUP_ENTRY(advanced, ProgrammingTrackSpaceConfigAdvanced,
+                Name("Advanced settings"));
 struct Shadow;
 CDI_GROUP_END();
 
@@ -61,13 +77,23 @@ struct ProgrammingTrackSpaceConfig::Shadow {
   uint32_t mode;
   uint32_t cv;
   uint32_t value;
+  uint32_t verify_repeats;
+  uint32_t verify_cooldown_repeats;
 };
 
 #define SHADOW_OFFSETOF(entry)                                          \
   ((uintptr_t) & ((ProgrammingTrackSpaceConfig::Shadow*)nullptr)->entry)
 
-static_assert(SHADOW_OFFSETOF(cv) == ProgrammingTrackSpaceConfig::zero_offset_this().cv().offset(), "Offset of CV field does not match.");
+static_assert(SHADOW_OFFSETOF(cv) ==
+                  ProgrammingTrackSpaceConfig::zero_offset_this().cv().offset(),
+              "Offset of CV field does not match.");
 
+static_assert(SHADOW_OFFSETOF(verify_cooldown_repeats) ==
+                  ProgrammingTrackSpaceConfig::zero_offset_this()
+                      .advanced()
+                      .repeat_cooldown_reset()
+                      .offset(),
+              "Offset of repeat cooldown reset field does not match.");
 
 } // namespace commandstation
 

--- a/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
+++ b/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
@@ -1,0 +1,77 @@
+/** \copyright
+ * Copyright (c) 2018, Balazs Racz
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are strictly prohibited without written consent.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file ProgrammingTrackSpaceConfig.hxx
+ *
+ * CDI configuration for the CV space to access the programming track flow.
+ *
+ * @author Balazs Racz
+ * @date 2 June 2018
+ */
+
+#ifndef _COMMANDSTATION_PROGRAMMINGTRACKSPACECONFIG_HXX_
+#define _COMMANDSTATION_PROGRAMMINGTRACKSPACECONFIG_HXX_
+
+#include "openlcb/ConfigRepresentation.hxx"
+
+namespace commandstation {
+
+static const char OPERATING_MODE_MAP_VALUES[] = R"(
+<relation><property>0</property><value>Disabled</value></relation>
+<relation><property>1</property><value>Direct mode</value></relation>
+<relation><property>10</property><value>Advanced mode</value></relation>
+)";
+
+
+CDI_GROUP(ProgrammingTrackSpaceConfig, Segment(0x15), Offset(0x7F100000),
+          Name("Programming track operation"),
+          Description("Use this component to read and write CVs on the "
+                      "programming track of the command station."));
+
+enum OperatingMode {
+  DISABLED = 0,
+  DIRECT_MODE = 1,
+  ADVANCED = 10,
+};
+
+CDI_GROUP_ENTRY(mode, openlcb::Uint32ConfigEntry, Name("Operating mode"), MapValues(OPERATING_MODE_MAP_VALUES));
+CDI_GROUP_ENTRY(cv, openlcb::Uint32ConfigEntry, Name("CV number"), Description("Number of CV to read or write (1..1024)."), Default(0), Min(0), Max(1024));
+CDI_GROUP_ENTRY(value, openlcb::Uint32ConfigEntry, Name("CV value"), Description("Read or write this field to access the given CV."), Default(0), Min(0), Max(255));
+struct Shadow;
+CDI_GROUP_END();
+
+/// This shadow structure is declared to be parallel to the CDI entries.
+struct ProgrammingTrackSpaceConfig::Shadow {
+  uint32_t mode;
+  uint32_t cv;
+  uint32_t value;
+};
+
+#define SHADOW_OFFSETOF(entry)                                          \
+  ((uintptr_t) & ((ProgrammingTrackSpaceConfig::Shadow*)nullptr)->entry)
+
+static_assert(SHADOW_OFFSETOF(cv) == ProgrammingTrackSpaceConfig::zero_offset_this().cv().offset(), "Offset of CV field does not match.");
+
+
+} // namespace commandstation
+
+
+
+#endif // _COMMANDSTATION_PROGRAMMINGTRACKSPACECONFIG_HXX_
+

--- a/cs/commandstation/UpdateProcessor.hxx
+++ b/cs/commandstation/UpdateProcessor.hxx
@@ -60,9 +60,10 @@ class UpdateProcessor : public StateFlow<Buffer<dcc::Packet>, QList<1> >,
   ~UpdateProcessor();
 
   /** Adds a new refresh source to the background refresh packets. */
-  void add_refresh_source(dcc::PacketSource* source,
+  bool add_refresh_source(dcc::PacketSource* source,
                           unsigned priority) OVERRIDE {
     AtomicHolder h(this);
+    bool ret = true;
     refreshSources_.push_back(source);
     hasRefreshSource_ = 1;
     auto& s = packetSourceStates_[source];
@@ -76,8 +77,15 @@ class UpdateProcessor : public StateFlow<Buffer<dcc::Packet>, QList<1> >,
       }
       if (priority > last_priority) {
         exclusiveIndex_ = refreshSources_.size() - 1;
+      } else {
+        ret = false;
+      }
+    } else {
+      if (exclusiveIndex_ != NO_EXCLUSIVE) {
+        ret = false;
       }
     }
+    return ret;
   }
   /** Deletes a packet refresh source. */
   void remove_refresh_source(dcc::PacketSource* source) OVERRIDE {


### PR DESCRIPTION
- Updates the commandstation code for API changes in the update loop
- Adds programming track frontend that drives the backend for user visible operations such as CV writes, reads and bit modify operations in service mode.
- Adds a memory space and its CDI configuration for executing programming commands from JMRI.