### PR TITLE
Fix marklin allocate

### DIFF
--- a/cs/commandstation/FindProtocolDefs.cxx
+++ b/cs/commandstation/FindProtocolDefs.cxx
@@ -255,10 +255,10 @@ openlcb::EventId FindProtocolDefs::input_to_event(const string& input) {
   }
   if (input.back() == 'm') {
     flags |= MARKLIN_OLD;
-  }  
+  }
   event &= ~UINT64_C(0xff);
   event |= (flags & 0xff);
-  
+
   return event;
 }
 

--- a/cs/commandstation/FindProtocolDefs.cxx
+++ b/cs/commandstation/FindProtocolDefs.cxx
@@ -238,7 +238,6 @@ openlcb::EventId FindProtocolDefs::input_to_event(const string& input) {
       if (!has_space) {
         qry <<= 4;
         qry |= 0xF;
-        event |= uint64_t(0xf) << shift;
         shift -= 4;
       }
       has_space = true;
@@ -246,6 +245,20 @@ openlcb::EventId FindProtocolDefs::input_to_event(const string& input) {
     pos++;
   }
   event |= uint64_t(qry & 0xFFFFFF) << TRAIN_FIND_MASK_LOW;
+  // @todo: figure out what flags we should exactly be giving here.
+  unsigned flags = 0;
+  if ((input[0] == '0') || (input.back() == 'L')) {
+    flags |= DCC_FORCE_LONG;
+  }
+  if (input.back() == 'M') {
+    flags |= MARKLIN_NEW;
+  }
+  if (input.back() == 'm') {
+    flags |= MARKLIN_OLD;
+  }  
+  event &= ~UINT64_C(0xff);
+  event |= (flags & 0xff);
+  
   return event;
 }
 
@@ -254,13 +267,6 @@ openlcb::EventId FindProtocolDefs::input_to_search(const string& input) {
     return openlcb::TractionDefs::IS_TRAIN_EVENT;
   }
   auto event = input_to_event(input);
-  // @todo: figure out what flags we should exactly be giving here.
-  unsigned flags = 0;
-  if (input[0] == '0') {
-    flags |= DCC_FORCE_LONG;
-  }
-  event &= ~UINT64_C(0xff);
-  event |= (flags & 0xff);
   return event;
 }
 
@@ -269,12 +275,7 @@ openlcb::EventId FindProtocolDefs::input_to_allocate(const string& input) {
     return 0;
   }
   auto event = input_to_event(input);
-  int mode = FindProtocolDefs::ALLOCATE | FindProtocolDefs::EXACT;
-  if (input[0] == '0') {
-    mode |= FindProtocolDefs::DCC_FORCE_LONG;
-  }
-  event &= ~UINT64_C(0xff);
-  event |= (mode & 0xff);
+  event |= (FindProtocolDefs::ALLOCATE | FindProtocolDefs::EXACT);
   return event;
 }
 

--- a/cs/commandstation/FindProtocolDefs.cxx
+++ b/cs/commandstation/FindProtocolDefs.cxx
@@ -245,15 +245,12 @@ openlcb::EventId FindProtocolDefs::input_to_event(const string& input) {
     pos++;
   }
   event |= uint64_t(qry & 0xFFFFFF) << TRAIN_FIND_MASK_LOW;
-  // @todo: figure out what flags we should exactly be giving here.
   unsigned flags = 0;
   if ((input[0] == '0') || (input.back() == 'L')) {
     flags |= DCC_FORCE_LONG;
-  }
-  if (input.back() == 'M') {
+  } else if (input.back() == 'M') {
     flags |= MARKLIN_NEW;
-  }
-  if (input.back() == 'm') {
+  } else if (input.back() == 'm') {
     flags |= MARKLIN_OLD;
   }
   event &= ~UINT64_C(0xff);

--- a/cs/commandstation/FindProtocolDefs.cxxtest
+++ b/cs/commandstation/FindProtocolDefs.cxxtest
@@ -75,13 +75,22 @@ TEST(InputToQueryTest, simplexlate) {
   // some more exotic
   EXPECT_EQ("090099FF013F4110", I2Q("013 41"));
   EXPECT_EQ("090099FF013F4110", I2Q("013///41"));
+
+  // Marklin
+  EXPECT_EQ("090099FFFFF13F02", I2Q("13M"));
 }
 
 TEST(InputToAllocTest, simplexlate) {
   EXPECT_EQ("090099FFFFFF13C0", I2A("13"));
   // Forced long
   EXPECT_EQ("090099FFFFF013D0", I2A("013"));
+  EXPECT_EQ("090099FFFFF13FD0", I2A("13L"));
+  EXPECT_EQ("090099FFFF013FD0", I2A("013L"));
   EXPECT_EQ("090099FFFF1234C0", I2A("1234"));
+
+  // Marklin
+  EXPECT_EQ("090099FFFFF12FC2", I2A("12M"));
+  EXPECT_EQ("090099FFFFF12FC1", I2A("12m"));
 }
 
 typedef FindProtocolDefs F;

--- a/cs/commandstation/FindProtocolDefs.hxx
+++ b/cs/commandstation/FindProtocolDefs.hxx
@@ -135,7 +135,7 @@ struct FindProtocolDefs {
    * IS_TRAIN_EVENT.
    */
   static openlcb::EventId input_to_search(const string& input);
-  
+
   /** Translates a sequence of input digits punched in by a throttle to an
    * allocate request to issue on the OpenLCB bus.
    *

--- a/cs/commandstation/FindProtocolDefs.hxx
+++ b/cs/commandstation/FindProtocolDefs.hxx
@@ -140,7 +140,9 @@ struct FindProtocolDefs {
    * allocate request to issue on the OpenLCB bus.
    *
    * @param input is the sequence of numbers that the user typed. This is
-   * expected to have form like '415' or '021' or '474014'
+   * expected to have form like '415' or '021' or '474014'. You can add a
+   * leading zero to force DCC long address, a trailing M to force a Marklin
+   * locomotive.
    * @return an event ID representing the search. This event ID will be zero if
    * the user input is invalid.
    */


### PR DESCRIPTION
Fixes bugs in the input parsing code that lead to problems allocating locomotives on the command station:

- spaces were not correctly handled
- trailing L and M letters now interpreted as longaddress and marklin locomotive selection.