### PR TITLE
Fix marklin allocate

### DIFF
--- a/cs/commandstation/FindProtocolDefs.cxx
+++ b/cs/commandstation/FindProtocolDefs.cxx
@@ -171,6 +171,17 @@ uint8_t FindProtocolDefs::match_query_to_node(openlcb::EventId event,
       address_prefix /= 10;
     }
   }
+  if (((mode & PROTOCOL_MASK) != 0) && (event & EXACT) && (event & ALLOCATE)) {
+    // Request specified a drive mode and allocation. We check the drive mode
+    // to match.
+    auto m1 = mode;
+    auto m2 = train->get_legacy_drive_mode();
+    if (m1 == MARKLIN_OLD) m1 = MARKLIN_NEW;
+    if (m2 == MARKLIN_OLD) m2 = MARKLIN_NEW;
+    if (m1 != m2) {
+      return 0;
+    }
+  }
   if (event & ADDRESS_ONLY) {
     if (((event & EXACT) != 0) || (!has_address_prefix_match)) return 0;
     return MATCH_ANY | ADDRESS_ONLY;

--- a/cs/commandstation/FindProtocolDefs.cxxtest
+++ b/cs/commandstation/FindProtocolDefs.cxxtest
@@ -110,11 +110,11 @@ TEST(MatchTest, testmatch) {
   EXPECT_EQ(0, // allocate will not match due to short vs long
             match("013", false, "FooBar777", 13, DCC_ANY));
 
-  EXPECT_EQ(0, // allocate will not match due to marklin vs dcc
+  EXPECT_EQ(0,  // allocate will not match due to marklin vs dcc
             match("13M", false, "FooBar777", 13, DCC_ANY));
-  EXPECT_NE(0, // this is marklin vs marklin
+  EXPECT_NE(0,  // this is marklin vs marklin
             match("13M", false, "FooBar777", 13, MARKLIN_NEW));
-  
+
   EXPECT_EQ(F::EXACT | F::ADDRESS_ONLY | F::MATCH_ANY,
             match("013", true, "FooBar777", 13, DCC_14_LONG_ADDRESS));
 

--- a/cs/commandstation/FindProtocolDefs.cxxtest
+++ b/cs/commandstation/FindProtocolDefs.cxxtest
@@ -110,6 +110,11 @@ TEST(MatchTest, testmatch) {
   EXPECT_EQ(0, // allocate will not match due to short vs long
             match("013", false, "FooBar777", 13, DCC_ANY));
 
+  EXPECT_EQ(0, // allocate will not match due to marklin vs dcc
+            match("13M", false, "FooBar777", 13, DCC_ANY));
+  EXPECT_NE(0, // this is marklin vs marklin
+            match("13M", false, "FooBar777", 13, MARKLIN_NEW));
+  
   EXPECT_EQ(F::EXACT | F::ADDRESS_ONLY | F::MATCH_ANY,
             match("013", true, "FooBar777", 13, DCC_14_LONG_ADDRESS));
 
@@ -127,6 +132,22 @@ TEST(MatchTest, longtoshortmatch) {
 
   // Another example in reverse: a short locomotive and a long address query.
   EXPECT_EQ(0, match("013", false, "13", 13, DCC_28));
+}
+
+TEST(MatchTest, marklinmatch) {
+  // In this test we have a dcc long address locomotive and then a marklin
+  // allocate arrives. The match should fail.
+  EXPECT_EQ(0, match("13M", false, "013L", 13, DCC_28_LONG_ADDRESS));
+  LOG(INFO, "2");
+  // Another example: a short locomotive and a marklin query.
+  EXPECT_EQ(0, match("13M", false, "13S", 13, DCC_28));
+
+  // In this test we have a marklin-old locomotive and then a marklin address
+  // allocate arrives.
+  EXPECT_NE(0, match("13M", false, "13m", 13, MARKLIN_OLD));
+
+  // Another example: a marklin-new loco and a marklin query.
+  EXPECT_NE(0, match("13M", false, "13M", 13, MARKLIN_NEW));
 }
 
 }  // namespace

--- a/cs/commandstation/TrainDbDefs.hxx
+++ b/cs/commandstation/TrainDbDefs.hxx
@@ -79,6 +79,9 @@ enum DccMode {
   DCC_28 = 5,
   DCC_128 = 6,
 
+  /// Bit mask for the protocol field only.
+  PROTOCOL_MASK = 7,
+
   DCC_ANY = 4,
   PUSHPULL = 8,
   MARKLIN_TWOADDR = 16,


### PR DESCRIPTION
Fixes bug that a marklin locomotive cannot be allocated if a DCC locomotive with the same number already exists.