### PR TITLE
Implements POM in the Programmingtrack Frontend and CV space

### DIFF
--- a/cs/commandstation/FindProtocolDefs.hxx
+++ b/cs/commandstation/FindProtocolDefs.hxx
@@ -84,6 +84,12 @@ struct FindProtocolDefs {
     NIBBLE_HASH = 0xb,
   };
 
+  /// @param event is an openlcb event ID
+  /// @return true if that event ID belong to the find protocol event range.
+  static bool is_find_event(openlcb::EventId event) {
+    return (event >> TRAIN_FIND_MASK) == (TRAIN_FIND_BASE >> TRAIN_FIND_MASK);
+  }
+
   /** Compares an incoming search query to a given train node. Returns 0 for a
       no-match. Returns a bitfield of match types for a match. valid bits are
       MATCH_ANY (always set), ADDRESS_ONLY (set when the match occurred in the

--- a/cs/commandstation/ProgrammingTrackFrontend.hxx
+++ b/cs/commandstation/ProgrammingTrackFrontend.hxx
@@ -126,8 +126,8 @@ struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
   uint8_t bitOffset_;
   /// Train address type.
   dcc::TrainAddressType addrType_;
-  /// For POM commands holds the DCC address to talk to. @todo describe how the
-  /// special (short / long) addresses are distinguished.
+  /// For POM commands holds the DCC address to talk to. Long vs short address
+  /// is defined by addrType_.
   uint16_t dccAddress_;
 };
 

--- a/cs/commandstation/ProgrammingTrackFrontend.hxx
+++ b/cs/commandstation/ProgrammingTrackFrontend.hxx
@@ -465,6 +465,7 @@ class ProgrammingTrackFrontend
     }
     b->data()->add_dcc_pom_read1(request()->cvOffset_);
     b->data()->feedback_key = reinterpret_cast<uintptr_t>(this);
+    b->data()->packet_header.rept_count = 3;
     railcomHub_->register_port(&railcomHandler_);
     seenRailcomBusy_ = 0;
     seenRailcomGarbage_ = 0;
@@ -479,6 +480,9 @@ class ProgrammingTrackFrontend
     if (errorCode_ == ERROR_OK) {
       request()->value_ = cvData_;
       return return_with_error(ERROR_CODE_OK);
+    }
+    if (errorCode_ == ERROR_PENDING) {
+      railcomHub_->unregister_port(&railcomHandler_);
     }
     if (++numTry_ < DEFAULT_POM_READ_RETRIES) {
       return call_immediately(STATE(pom_read_byte));

--- a/cs/commandstation/ProgrammingTrackFrontend.hxx
+++ b/cs/commandstation/ProgrammingTrackFrontend.hxx
@@ -30,6 +30,7 @@
 
 #include "executor/CallableFlow.hxx"
 #include "dcc/ProgrammingTrackBackend.hxx"
+#include "dcc/Defs.hxx"
 
 #ifdef LOGLEVEL
 #undef LOGLEVEL
@@ -43,6 +44,8 @@ struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
   enum DirectWriteBit { DIRECT_WRITE_BIT };
   enum DirectReadByte { DIRECT_READ_BYTE };
   enum DirectReadBit { DIRECT_READ_BIT };
+  enum PomWriteByte { POM_WRITE_BYTE };
+  enum PomReadByte { POM_READ_BYTE };
 
   /// Request to write a byte sized CV in direct mode.
   /// @param cv_number is the 1-based CV number (as the user sees it).
@@ -54,11 +57,38 @@ struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
     value_ = value;
   }
 
+  /// Request to write a byte sized CV in pom mode.
+  /// @param addrtype defines whether short or long address.
+  /// @param dcc_address is the DCC address of the target locomotive.
+  /// @param cv_number is the 1-based CV number (as the user sees it).
+  /// @param value is the value to set the CV to.
+  void reset(PomWriteByte, dcc::TrainAddressType addrtype, uint32_t dcc_address, unsigned cv_number, uint8_t value) {
+    reset_base();
+    cmd_ = Type::POM_WRITE_BYTE;
+    addrType_ = addrtype;
+    dccAddress_ = dcc_address;
+    cvOffset_ = cv_number - 1;
+    value_ = value;
+  }
+
   /// Request to read a byte sized CV in direct mode.
   /// @param cv_number is the 1-based CV number (as the user sees it).
   void reset(DirectReadByte, unsigned cv_number) {
     reset_base();
     cmd_ = Type::DIRECT_READ_BYTE;
+    cvOffset_ = cv_number - 1;
+    value_ = 0;
+  }
+
+  /// Request to read a byte sized CV in POM using RailCom.
+  /// @param addrtype defines whether short or long address.
+  /// @param dcc_address is the DCC address of the target locomotive.
+  /// @param cv_number is the 1-based CV number (as the user sees it).
+  void reset(PomReadByte, dcc::TrainAddressType addrtype, uint32_t dcc_address, unsigned cv_number) {
+    reset_base();
+    cmd_ = Type::POM_READ_BYTE;
+    addrType_ = addrtype;
+    dccAddress_ = dcc_address;
     cvOffset_ = cv_number - 1;
     value_ = 0;
   }
@@ -80,7 +110,9 @@ struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
     DIRECT_WRITE_BYTE,
     DIRECT_WRITE_BIT,
     DIRECT_READ_BYTE,
-    DIRECT_READ_BIT
+    DIRECT_READ_BIT,
+    POM_WRITE_BYTE,
+    POM_READ_BYTE
   };
 
   /// What is the instruction to do.
@@ -92,13 +124,23 @@ struct ProgrammingTrackFrontendRequest : public CallableFlowRequestBase {
   uint8_t value_;
   /// Which bit number to program (0..7).
   uint8_t bitOffset_;
+  /// Train address type.
+  dcc::TrainAddressType addrType_;
+  /// For POM commands holds the DCC address to talk to. @todo describe how the
+  /// special (short / long) addresses are distinguished.
+  uint16_t dccAddress_;
 };
 
-class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendRequest> {
+class ProgrammingTrackFrontend
+    : public CallableFlow<ProgrammingTrackFrontendRequest> {
  public:
-  ProgrammingTrackFrontend(ProgrammingTrackBackend* backend)
-      : CallableFlow<ProgrammingTrackFrontendRequest>(backend->service())
-      , backend_(backend) {}
+  ProgrammingTrackFrontend(ProgrammingTrackBackend* backend,
+                           dcc::PacketFlowInterface* track,
+                           dcc::RailcomHubFlow* railcom_hub)
+      : CallableFlow<ProgrammingTrackFrontendRequest>(backend->service()),
+        backend_(backend),
+        track_(track),
+        railcomHub_(railcom_hub) {}
 
   typedef ProgrammingTrackFrontendRequest::Type RequestType;
 
@@ -111,8 +153,12 @@ class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendReq
     /// Re-triable error generated when the loco respons with conflicting
     /// information.
     ERROR_FAILED_VERIFY = openlcb::Defs::ERROR_OPENLCB_TIMEOUT | 2,
+    /// We have not received any railcom response from the locomotive.
+    ERROR_NO_RAILCOM = openlcb::Defs::ERROR_OPENLCB_TIMEOUT | 3,
     /// Error code when something was invoked that is not implemented.
     ERROR_UNIMPLEMENTED_CMD = openlcb::Defs::ERROR_UNIMPLEMENTED_CMD,
+    /// Error code when the request arguments are invalid.
+    ERROR_INVALID_ARGS = openlcb::Defs::ERROR_INVALID_ARGS,
     /// cleared when done is called.
     OPERATION_PENDING = openlcb::DatagramClient::OPERATION_PENDING,
   };
@@ -137,9 +183,14 @@ class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendReq
       case RequestType::DIRECT_READ_BYTE:
       case RequestType::DIRECT_READ_BIT:
         return call_immediately(STATE(enter_service_mode));
-      default:
-        return return_with_error(ERROR_UNIMPLEMENTED_CMD);
+      case RequestType::POM_READ_BYTE:
+        numTry_ = 0;
+        return call_immediately(STATE(pom_read_byte));
+      case RequestType::POM_WRITE_BYTE:
+        numTry_ = 0;
+        return call_immediately(STATE(pom_write_byte));
     }
+    return return_with_error(ERROR_UNIMPLEMENTED_CMD);
   }
 
   Action enter_service_mode() {
@@ -340,12 +391,196 @@ class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendReq
         backend_, STATE(return_response),
         ProgrammingTrackRequest::EXIT_SERVICE_MODE);
   }
-  
+
   Action return_response() {
     auto b = get_buffer_deleter(full_allocation_result(backend_));
     return return_with_error(request()->resultCode & (~OPERATION_PENDING));
   }
 
+  Action pom_write_byte() {
+    return allocate_and_call(track_, STATE(fill_pom_write_byte_packet));
+  }
+
+  Action fill_pom_write_byte_packet() {
+    auto b = get_buffer_deleter(get_allocation_result(track_));
+    b->data()->start_dcc_packet();
+    if (request()->addrType_ == dcc::TrainAddressType::DCC_SHORT_ADDRESS) {
+      b->data()->add_dcc_address(dcc::DccShortAddress(request()->dccAddress_));
+    } else if (request()->addrType_ == dcc::TrainAddressType::DCC_LONG_ADDRESS) {
+      b->data()->add_dcc_address(dcc::DccLongAddress(request()->dccAddress_));
+    } else {
+      return return_with_error(ERROR_INVALID_ARGS);
+    }
+    b->data()->add_dcc_pom_write1(request()->cvOffset_, request()->value_);
+    b->data()->feedback_key = reinterpret_cast<uintptr_t>(this);
+    // POM write packets need to appear at least twice on non-back-to-back
+    // packets by the standard. We make 4 back to back packets and that
+    // fulfills the requirement.
+    b->data()->packet_header.rept_count = 3;
+    railcomHub_->register_port(&railcomHandler_);
+    seenRailcomBusy_ = 0;
+    seenRailcomGarbage_ = 0;
+    errorCode_ = ERROR_PENDING;
+    track_->send(b.release());
+    return sleep_and_call(&timer_, MSEC_TO_NSEC(500), STATE(write_returned));
+  }
+
+  Action write_returned() {
+    LOG(INFO, "railcom write returned status %d value %d", errorCode_,
+        cvData_);
+    switch (errorCode_) {
+      case ERROR_PENDING:
+        railcomHub_->unregister_port(&railcomHandler_);
+        if (seenRailcomBusy_ &&
+            (++numTry_ < DEFAULT_POM_WRITE_RETRIES_ON_BUSY)) {
+          return sleep_and_call(&timer_, MSEC_TO_NSEC(100),
+                                STATE(pom_write_byte));
+        }
+        if (seenRailcomBusy_ || seenRailcomGarbage_) {
+          return return_with_error(ERROR_FAILED_VERIFY);
+        } else {
+          return return_with_error(ERROR_NO_RAILCOM);
+        }
+        break;
+      case ERROR_OK:
+        return return_with_error(ERROR_CODE_OK);
+    }
+    // Should not get here.
+    return return_with_error(openlcb::Defs::ERROR_TEMPORARY);
+  }
+
+  Action pom_read_byte() {
+    return allocate_and_call(track_, STATE(fill_pom_read_byte_packet));
+  }
+
+  Action fill_pom_read_byte_packet() {
+    auto b = get_buffer_deleter(get_allocation_result(track_));
+    b->data()->start_dcc_packet();
+    if (request()->addrType_ == dcc::TrainAddressType::DCC_SHORT_ADDRESS) {
+      b->data()->add_dcc_address(dcc::DccShortAddress(request()->dccAddress_));
+    } else if (request()->addrType_ == dcc::TrainAddressType::DCC_LONG_ADDRESS) {
+      b->data()->add_dcc_address(dcc::DccLongAddress(request()->dccAddress_));
+    } else {
+      return return_with_error(ERROR_INVALID_ARGS);
+    }
+    b->data()->add_dcc_pom_read1(request()->cvOffset_);
+    b->data()->feedback_key = reinterpret_cast<uintptr_t>(this);
+    railcomHub_->register_port(&railcomHandler_);
+    seenRailcomBusy_ = 0;
+    seenRailcomGarbage_ = 0;
+    errorCode_ = ERROR_PENDING;
+    track_->send(b.release());
+    return sleep_and_call(&timer_, MSEC_TO_NSEC(500), STATE(read_returned));
+  }
+
+  Action read_returned() {
+    LOG(WARNING, "railcom read returned status %d value %d", errorCode_,
+        cvData_);
+    if (errorCode_ == ERROR_OK) {
+      request()->value_ = cvData_;
+      return return_with_error(ERROR_CODE_OK);
+    }
+    if (++numTry_ < DEFAULT_POM_READ_RETRIES) {
+      return call_immediately(STATE(pom_read_byte));
+    }
+    if (seenRailcomBusy_ || seenRailcomGarbage_) {
+      return return_with_error(ERROR_FAILED_VERIFY);
+    } else {
+      return return_with_error(ERROR_NO_RAILCOM);
+    }
+  }
+
+  /// Handler class for railcom feedback messages.
+  class RailcomHandler : public dcc::RailcomHubPortInterface {
+   public:
+    RailcomHandler(ProgrammingTrackFrontend* parent)
+        : parent_(parent) {}
+    void send(Buffer<dcc::RailcomHubData>* b, unsigned priority) override {
+      parent_->railcom_feedback(b, priority);
+    }
+   private:
+    ProgrammingTrackFrontend* parent_;
+  } railcomHandler_{this};
+
+  // Railcom feedback callback.
+  void railcom_feedback(Buffer<dcc::RailcomHubData>* b, unsigned priority) {
+    AutoReleaseBuffer<dcc::RailcomHubData> ar(b);
+    if (errorCode_ != ERROR_PENDING) return;
+    const dcc::Feedback& f = *b->data();
+    if (f.feedbackKey != (reinterpret_cast<uintptr_t>(this))) {
+      // not for me.
+      if (seenRailcomBusy_ && (errorCode_ == ERROR_PENDING)) {
+        // All repeats have returned busy.
+        return record_railcom_status(_ERROR_BUSY);
+      }
+      return;
+    }
+    if (f.channel == 0xff) {
+      // also skip the railcom-based occupancy information packets.
+      return;
+    }
+    LOG(INFO, "CV railcom feedback ch=%d: %s", f.channel,
+        railcom_debug(f).c_str());
+    if (!f.ch2Size) {
+      return record_railcom_status(ERROR_NO_RAILCOM_CH2_DATA);
+    }
+    dcc::parse_railcom_data(f, &interpretedResponse_);
+    unsigned new_status = ERROR_PENDING;
+    for (const auto& e : interpretedResponse_) {
+      if (e.railcom_channel != 2) continue;
+      switch (e.type) {
+        case dcc::RailcomPacket::BUSY:
+          // We wait for another repeat of the packet to return some other
+          // status.
+          seenRailcomBusy_ = 1;
+          break;
+        case dcc::RailcomPacket::NACK:
+          if (new_status == ERROR_PENDING) {
+            // We ignore NACK responses because certain versions of the
+            // standard had NACK interpreted the same way as ACK as well as
+            // it was being used as a filler. There are locomotives out
+            // there who do this.
+            // new_status = ERROR_NACK;
+          }
+          break;
+        case dcc::RailcomPacket::ACK:
+          if (new_status == ERROR_PENDING) {
+            new_status = ERROR_OK;
+          }
+          break;
+        case dcc::RailcomPacket::MOB_POM:
+          cvData_ = e.argument;
+          new_status = ERROR_OK;
+          break;
+        case dcc::RailcomPacket::GARBAGE:
+          seenRailcomGarbage_ = 1;
+          if (new_status == ERROR_PENDING) {
+            // We rather ignore garbage and wait for real data.
+            // new_status = ERROR_GARBAGE;
+          }
+          break;
+        default:
+          seenRailcomGarbage_ = 1;
+          if (new_status == ERROR_PENDING) {
+            // We rather ignore unknown packets and wait for real data.
+            //new_status = ERROR_UNKNOWN_RESPONSE;
+          }
+          break;
+      }
+    }
+    if (new_status == ERROR_PENDING) {
+      // No meaningful information received.
+      return;
+    }
+    return record_railcom_status(new_status);
+  }
+
+  void record_railcom_status(unsigned code) {
+    errorCode_ = code;
+    timer_.trigger();
+    railcomHub_->unregister_port(&railcomHandler_);
+  }
+  
  private:
   /// How many times by default we send out a programming track verify packet
   /// to get exactly one ack.
@@ -356,9 +591,33 @@ class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendReq
 
   /// How many times by default we send out a programming track write packet.
   static constexpr unsigned DEFAULT_WRITE_REPEATS = 5;
+  /// How many times a POM write should be retries when the decoder sends back
+  /// BUSY.
+  static constexpr unsigned DEFAULT_POM_WRITE_RETRIES_ON_BUSY = 3;
+  /// How many times to retry POM read commands if we don't get a POM response
+  /// in railcom.
+  static constexpr unsigned DEFAULT_POM_READ_RETRIES = 3;
 
-  /// Which bits were confirmed to be ones by the decoder.
-  uint8_t confirmedOnes_;
+  /// Error codes used by the POM railcom readout.
+  enum {
+    ERROR_NOOP = 0,
+    ERROR_PENDING = 1,
+    ERROR_OK = 2,
+    _ERROR_BUSY = 3,
+    ERROR_NACK = 7,
+    ERROR_NO_RAILCOM_CH2_DATA = 4,
+    ERROR_GARBAGE = 5,
+    ERROR_UNKNOWN_RESPONSE = 6,
+    _ERROR_TIMEOUT = 8,
+  };
+
+  union {
+    /// Which bits were confirmed to be ones by the decoder.
+    uint8_t confirmedOnes_;
+
+    /// Railcom data read-out payload.
+    uint8_t cvData_;
+  };
   /// Which bits were confirmed to be zeros by the decoder.
   uint8_t confirmedZeros_;
   /// The number of times we have to send out a verify packet to get one
@@ -373,8 +632,25 @@ class ProgrammingTrackFrontend : public CallableFlow<ProgrammingTrackFrontendReq
   uint8_t foundAck_ : 1;
   /// 1 if the write request has seen an ack pulse.
   uint8_t hasWriteAck_ : 1;
+  /// RailCom error code returned.
+  uint8_t errorCode_ : 4;
+  /// POM re-try attempts.
+  uint8_t numTry_ : 4;
+  /// 1 if we have seen a returned BUSY response from railcom.
+  uint8_t seenRailcomBusy_ : 1;
+  /// 1 if we have seen any unknown or garbage data from railcom.
+  uint8_t seenRailcomGarbage_ : 1;
+  
+  StateFlowTimer timer_{this};
+  long long deadline_;  //< time when we should give up and return error.
+  vector<dcc::RailcomPacket> interpretedResponse_;
+
   /// Backend flow for executing low-level programming track requests.
   ProgrammingTrackBackend* backend_;
+  /// Track interface to send POM packets to.
+  dcc::PacketFlowInterface *track_;
+  /// Hub where railcom feedback packets can come in.
+  dcc::RailcomHubFlow *railcomHub_;
   /// Holding buffer for the next programming track packet to send.
   dcc::Packet serviceModePacket_;
 };

--- a/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
+++ b/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
@@ -29,6 +29,7 @@
 #define _COMMANDSTATION_PROGRAMMINGTRACKSPACECONFIG_HXX_
 
 #include "openlcb/ConfigRepresentation.hxx"
+#include "openlcb/MemoryConfig.hxx"
 
 namespace commandstation {
 
@@ -54,7 +55,7 @@ CDI_GROUP_ENTRY(
     Default(6), Min(0), Max(255));
 CDI_GROUP_END();
 
-CDI_GROUP(ProgrammingTrackSpaceConfig, Segment(0x15), Offset(0x7F100000),
+CDI_GROUP(ProgrammingTrackSpaceConfig, Segment(openlcb::MemoryConfigDefs::SPACE_DCC_CV), Offset(0x7F100000),
           Name("Programming track operation"),
           Description("Use this component to read and write CVs on the "
                       "programming track of the command station."));

--- a/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
+++ b/cs/commandstation/ProgrammingTrackSpaceConfig.hxx
@@ -35,6 +35,7 @@ namespace commandstation {
 static const char OPERATING_MODE_MAP_VALUES[] = R"(
 <relation><property>0</property><value>Disabled</value></relation>
 <relation><property>1</property><value>Direct mode</value></relation>
+<relation><property>2</property><value>POM mode</value></relation>
 <relation><property>10</property><value>Advanced mode</value></relation>
 )";
 
@@ -61,6 +62,7 @@ CDI_GROUP(ProgrammingTrackSpaceConfig, Segment(0x15), Offset(0x7F100000),
 enum OperatingMode {
   DISABLED = 0,
   DIRECT_MODE = 1,
+  POM_MODE = 2,
   ADVANCED = 10,
 };
 

--- a/cs/commandstation/TrainDbCdi.hxx
+++ b/cs/commandstation/TrainDbCdi.hxx
@@ -38,8 +38,8 @@
 #include "ConfigLocal.hxx"
 
 #include "openlcb/ConfigRepresentation.hxx"
-#include "openlcb/TractionCvCdi.hxx"
 #include "commandstation/TrainDbDefs.hxx"
+#include "commandstation/ProgrammingTrackSpaceConfig.hxx"
 
 namespace commandstation {
 
@@ -133,7 +133,7 @@ CDI_GROUP(TrainConfigDef, MainCdi());
 // information in here because both of these vary train by train.
 CDI_GROUP_ENTRY(ident, openlcb::Identification, Model("Virtual train node"));
 CDI_GROUP_ENTRY(train, TrainSegment);
-CDI_GROUP_ENTRY(cv, openlcb::TractionShortCvSpace);
+CDI_GROUP_ENTRY(cv, ProgrammingTrackSpaceConfig);
 CDI_GROUP_END();
 
 CDI_GROUP(TmpTrainSegment, Segment(openlcb::MemoryConfigDefs::SPACE_CONFIG),
@@ -149,7 +149,7 @@ CDI_GROUP_END();
 CDI_GROUP(TrainTmpConfigDef, MainCdi());
 CDI_GROUP_ENTRY(ident, openlcb::Identification, Model("Virtual train node"));
 CDI_GROUP_ENTRY(train, TmpTrainSegment);
-CDI_GROUP_ENTRY(cv, openlcb::TractionShortCvSpace);
+CDI_GROUP_ENTRY(cv, ProgrammingTrackSpaceConfig);
 CDI_GROUP_END();
 
 using TrainDbConfig =


### PR DESCRIPTION
Adds POM support to the ProgrammingTrack CV space classes:
- implements set_node() in the MemorySpace to allow TrainNodes to accept read and write commands
- separates the frontend call depending on what the last set node ID was.
- adds separate POM_{WRITE|READ}_BYTE command to the PRogrammingTrack Frontend 
- implennets the railcom based POM query and write commands in the Frontend, wihtout involving the actual programmingtrack backend.

Also a feature update in FindTrainNode: allows using RemoteFindTrainNode to be used to search for producer for any event ID.