### PR TITLE
Add support for search by protocol.

### DIFF
--- a/cs/commandstation/FindProtocolDefs.hxx
+++ b/cs/commandstation/FindProtocolDefs.hxx
@@ -90,6 +90,15 @@ struct FindProtocolDefs {
     return (event >> TRAIN_FIND_MASK) == (TRAIN_FIND_BASE >> TRAIN_FIND_MASK);
   }
 
+  /// Compares an incoming search query's drive mode bits to an actual drive
+  /// mode of a locomotive. Decides whether they match using tri-state logic,
+  /// i.e. taking into account "no restriction" queries.
+  /// @param event the incoming query
+  /// @param mode the drive mode of a locomotive
+  /// @return true if this locomotive matches the restrictions in the query
+  /// (true if there were no restrictions in the query).
+  static bool match_event_to_drive_mode(openlcb::EventId event, DccMode mode);
+  
   /** Compares an incoming search query to a given train node. Returns 0 for a
       no-match. Returns a bitfield of match types for a match. valid bits are
       MATCH_ANY (always set), ADDRESS_ONLY (set when the match occurred in the

--- a/cs/commandstation/FindProtocolServer.cxxtest
+++ b/cs/commandstation/FindProtocolServer.cxxtest
@@ -36,6 +36,7 @@ class FindProtocolTest : public AllTrainNodesTest {
     uint64_t event = create_query(nibbles, settings);
     LOG(INFO, "query event: %016" PRIX64, event);
     for (uint16_t alias : results) {
+      SCOPED_TRACE(alias);
       LOG(INFO, "expected result: %x", (unsigned)alias);
       expect_packet(StringPrintf(":X19544%03XN%016" PRIX64 ";", alias, event));
     }
@@ -350,7 +351,8 @@ TEST_F(FindProtocolTest, BunchOfQueries) {
   find_nodes(0x000465, 0, {0x442});
   find_nodes(0xFFFF46, 0, {0x442, 0x441});
   find_nodes(0xFFFFF4, 0, {0x442, 0x441, 0x440});
-  find_nodes(0xFFFFFF, 0, {});
+  print_all_packets();
+  find_nodes(0xFFFFFF, 0, {0x442, 0x441, 0x440});
   find_nodes(0xFFFFFF, FindProtocolDefs::ADDRESS_ONLY, {});
 }
 
@@ -567,7 +569,7 @@ TEST_F(MatchNodeTest, multi_part_name) {
 }
 
 TEST_F(MatchNodeTest, emptyqry) {
-  EXPECT_FALSE(check_match(0xFFFFFF, 0, "BR 123", 555));
+  EXPECT_EQ(MATCH_ANY, check_match(0xFFFFFF, 0, "BR 123", 555));
 }
 
 }  // namespace commandstation

--- a/cs/commandstation/FindProtocolServer.cxxtest
+++ b/cs/commandstation/FindProtocolServer.cxxtest
@@ -477,12 +477,15 @@ TEST_F(MatchNodeTest, with_protocol) {
   // Baseline.
   EXPECT_EQ(MATCH_ANY | ADDRESS_ONLY | EXACT,
             check_match(0xFFF123, FindProtocolDefs::EXACT, "Foo", 123));
-  // If the protocol is specified, we return a non-exact match only.
-  EXPECT_EQ(MATCH_ANY | ADDRESS_ONLY,
-            check_match(0xFFF123, MARKLIN_NEW, "Foo", 123));
-  // If exact is needed, no match.
-  EXPECT_FALSE(
-      check_match(0xFFF123, FindProtocolDefs::EXACT | MARKLIN_NEW, "Foo", 123));
+  // If the protocol is specified to be MARKLIN, there is no match as the train
+  // is DCC.
+  EXPECT_FALSE(check_match(0xFFF123, MARKLIN_ANY, "Foo", 123, DCC_28));
+  // But if the train is also marklin, that is fine.
+  EXPECT_EQ(MATCH_ANY | ADDRESS_ONLY | EXACT,
+      check_match(0xFFF123, MARKLIN_ANY, "Foo", 123, MARKLIN_NEW));
+  // If exact is needed, but protocols don't match, no match either.
+  EXPECT_FALSE(check_match(0xFFF123, FindProtocolDefs::EXACT | MARKLIN_NEW,
+                           "Foo", 123, DCC_28));
 
   // A DCC long address received matched against a short-addressed train:
   EXPECT_FALSE(

--- a/cs/commandstation/FindTrainNode.cxxtest
+++ b/cs/commandstation/FindTrainNode.cxxtest
@@ -56,7 +56,7 @@ class FindTrainNodeTest : public TrainDbTest {
   FindTrainNode findFlow_{node_, &db_, &allTrainNodes_};
 
   openlcb::TrainNodeWithId olcbTrain_{&trainService_, &m1_, 0x0501010118DD};
-  ExternalTrainDbEntry dbEntry_{"Deadrail 415", 415, DCCMODE_FAKE_DRIVE};
+  ExternalTrainDbEntry dbEntry_{"Deadrail 415", 415, DCCMODE_OLCBUSER};
   SingleNodeFindProtocolServer findProtocolServer_{&olcbTrain_, &dbEntry_};  
 };
 
@@ -199,7 +199,7 @@ TEST_F(RemoteFindTrainNodeTest, FindRemoteTrainWithAddressLookup) {
 }
 
 TEST_F(RemoteFindTrainNodeTest, FindNonMatchingTrain) {
-  auto b = invoke_flow(&remoteClient_, 234, true, DCCMODE_OLCBUSER);
+  auto b = invoke_flow(&remoteClient_, 234, true, DCCMODE_DEFAULT);
   EXPECT_EQ(openlcb::Defs::ERROR_OPENMRN_NOT_FOUND, b->data()->resultCode);
   EXPECT_EQ(0u, b->data()->nodeId);
 }
@@ -228,7 +228,7 @@ TEST_F(RemoteFindTrainNodeTest, FindTwoTrainCallback) {
   RemoteFindTrainNodeRequest::ResultFn rf =
       std::bind(&FindResponse::response, &responseMock_, std::placeholders::_1,
                 std::placeholders::_2);
-  auto b = invoke_flow(&remoteClient_, 2, false, DCCMODE_OLCBUSER, rf);
+  auto b = invoke_flow(&remoteClient_, 2, false, DCCMODE_DEFAULT, rf);
   EXPECT_EQ(0, b->data()->resultCode);
   EXPECT_EQ(0u, b->data()->nodeId);
 }

--- a/cs/commandstation/TrainDbDefs.hxx
+++ b/cs/commandstation/TrainDbDefs.hxx
@@ -182,6 +182,14 @@ enum DccMode {
   DCCMODE_PROTOCOL_MASK = 0b11111,
 };
 
+/// Converts a DccMode bit mask and a legacy address into a TrainAddressType
+/// enum.
+/// @param mode the legacy drive mode (e.g. from a TrainDb entry or from a search query)
+/// @param address is the legacy address.
+/// @return an enum value which together with the address uniquely represents
+/// an addressable entity on the track. May return UNSPECIFIED if DccMode ==
+/// DCCMODE_DEFAULT (usually a query did not specify any restriction) or
+/// UNSUPPORTED if we did not recognize the code in the DccMode bitfield.
 inline dcc::TrainAddressType dcc_mode_to_address_type(DccMode mode,
                                                       uint32_t address) {
   if (mode == DCCMODE_DEFAULT) {
@@ -198,6 +206,27 @@ inline dcc::TrainAddressType dcc_mode_to_address_type(DccMode mode,
   }
   LOG(INFO, "Unsupported drive mode %d (0x%02x)", mode, mode);
   return dcc::TrainAddressType::UNSUPPORTED;
+}
+
+/// Converts a DccMode bit mask down to a protocol enumeration, i.e. DCC,
+/// Marklin or OpenLCB.
+/// @param mode the detailed mode bit field.
+/// @return a stripped down mode bit field which does not specify any details
+/// about the protocol variant.
+inline DccMode dcc_mode_to_protocol(DccMode mode) {
+  if (mode == DCCMODE_DEFAULT ||
+      mode == DCCMODE_OLCBUSER) {
+    return mode;
+  }
+  if ((mode & MARKLIN_ANY_MASK) == MARKLIN_ANY) {
+    return MARKLIN_ANY;
+  }
+  if ((mode & DCC_ANY_MASK) == DCC_ANY) {
+    return DCC_ANY;
+  }
+  LOG(INFO, "Unknown DCC Mode %d", (int)mode);
+  // We return the value unchanged.
+  return mode;
 }
 
 } // namespace commandstation

--- a/cs/commandstation/TrainNodeInfoCache.cxxtest
+++ b/cs/commandstation/TrainNodeInfoCache.cxxtest
@@ -158,7 +158,7 @@ TEST_F(FindManyTrainTestBase, Create) {}
 
 TEST_F(FindManyTrainTestBase, Search7) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(7, false, DCCMODE_OLCBUSER);
+  b->data()->reset(7, false, DCC_ANY);
   print_all_packets();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
   EXPECT_CALL(mockNotifiable_, notify()).Times(AtLeast(1));
@@ -176,7 +176,7 @@ TEST_F(FindManyTrainTestBase, Search7) {
 
 TEST_F(FindManyTrainTestBase, Search5) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(5, false, DCCMODE_OLCBUSER);
+  b->data()->reset(5, false, DCC_ANY);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -206,7 +206,7 @@ TEST_F(FindManyTrainTestBase, Search5) {
   printf("restrict search.\n");
   // Restrict the search
   b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(51, false, DCCMODE_OLCBUSER);
+  b->data()->reset(51, false, DCCMODE_DEFAULT);
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
   EXPECT_CALL(mockNotifiable_, notify()).Times(2); // no new SNIP lookup.
   EXPECT_CALL(canBus_, mwrite(_)).Times(AtMost(7));
@@ -238,7 +238,7 @@ TEST_F(FindManyTrainTestBase, Search5) {
 TEST_F(FindManyTrainTestBase, PageSize) {
   trainCache_.set_nodes_to_show(2);
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(5, false, DCCMODE_OLCBUSER);
+  b->data()->reset(5, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -254,7 +254,7 @@ TEST_F(FindManyTrainTestBase, ScrollToLastLine) {
   trainCache_.set_nodes_to_show(2);
   trainCache_.set_scroll_to_last_line(true);
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(5, false, DCCMODE_OLCBUSER);
+  b->data()->reset(5, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -291,7 +291,7 @@ TEST_F(FindManyTrainTestBase, ScrollToLastLine) {
 
 TEST_F(FindManyTrainTestBase, Scroll3) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(3, false, DCCMODE_OLCBUSER);
+  b->data()->reset(3, false, DCCMODE_DEFAULT);
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
   EXPECT_CALL(mockNotifiable_, notify()).Times(AtLeast(1));
@@ -369,7 +369,7 @@ TEST_F(FindManyTrainTestBase, Scroll3) {
 
 TEST_F(FindManyTrainTestBase, BidirScrollNoPage) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(5, false, DCCMODE_OLCBUSER);
+  b->data()->reset(5, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -401,7 +401,7 @@ TEST_F(FindManyTrainTestBase, BidirScrollNoPage) {
 
 TEST_F(FindManyTrainTestBase, BidirScrollWithPage) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(3, false, DCCMODE_OLCBUSER);
+  b->data()->reset(3, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -476,7 +476,7 @@ TEST_F(FindManyTrainTestBase, BidirScrollWithPage) {
 
 TEST_F(FindManyTrainTestBase, PrefetchTest) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(3, false, DCCMODE_OLCBUSER);
+  b->data()->reset(3, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -540,7 +540,7 @@ TEST_F(FindManyTrainTestBase, PrefetchTest) {
 
 TEST_F(FindManyTrainTestBase, ScrollToTest) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(3, false, DCCMODE_OLCBUSER);
+  b->data()->reset(3, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);
@@ -611,7 +611,7 @@ TEST_F(FindManyTrainTestBase, ScrollToTest) {
 
 TEST_F(FindManyTrainTestBase, ScrollToTestEmpty) {
   auto b = get_buffer_deleter(remoteClient_.alloc());
-  b->data()->reset(831, false, DCCMODE_OLCBUSER);
+  b->data()->reset(831, false, DCCMODE_DEFAULT);
 
   expect_any_packet();
   trainCache_.reset_search(std::move(b), &mockNotifiable_);

--- a/cs/commandstation/cm_test_helper.hxx
+++ b/cs/commandstation/cm_test_helper.hxx
@@ -90,7 +90,20 @@ class AllTrainNodesTestBase : public openlcb::TractionTest {
     expect_packet(
         StringPrintf(":X19524%03XN090099FF00000000;", alias));
   }
-  
+
+  /// Sends an addressed message to the bus. Performs
+  /// synchronous (dynamic) memory allocation so use it sparingly and when
+  /// there is sufficient amount of RAM available.
+  /// @param mti is the message to send
+  /// @param dst is the node to send message to.
+  /// @param payload is the contents of the message
+  void send_message_to(openlcb::Defs::MTI mti, openlcb::NodeHandle dst,
+                       const string& payload = openlcb::EMPTY_PAYLOAD) {
+    auto *b = node_->iface()->addressed_message_write_flow()->alloc();
+    b->data()->reset(mti, node_->node_id(), dst, payload);
+    node_->iface()->addressed_message_write_flow()->send(b);
+  }
+
   openlcb::ConfigUpdateFlow updateFlow_{ifCan_.get()};
   openlcb::SimpleInfoFlow infoFlow_{&g_service};
   openlcb::CanDatagramService datagramService_{ifCan_.get(), 5, 2};


### PR DESCRIPTION
Makes the find protocol matching algorithm take into account when a protocol restriction
is applied to the find query.

Normally throttles will not specify a protocol restriction (send DEFAULT / 0),
and that returns all trains. But when the throttle does specify the protocol,
we must make sure to return trains only from that protocol.

Adjusts some of the unittests which have incorrectly specified the query parameters.