### PR TITLE
 Adds an abstract interface to decouple AllTrainNodes from FindProtocolServer.

### DIFF
--- a/cs/commandstation/AllTrainNodes.cxx
+++ b/cs/commandstation/AllTrainNodes.cxx
@@ -170,13 +170,13 @@ AllTrainNodes::Impl* AllTrainNodes::find_node(openlcb::NodeID node_id) {
 }
 
 /// Returns a traindb entry or nullptr if the id is too high.
-std::shared_ptr<TrainDbEntry> AllTrainNodes::get_traindb_entry(int id) {
+std::shared_ptr<TrainDbEntry> AllTrainNodes::get_traindb_entry(size_t id) {
   return db_->get_entry(id);
 }
 
 /// Returns a node id or 0 if the id is not known to be a train.
-openlcb::NodeID AllTrainNodes::get_train_node_id(int id) {
-  if (id >= (int)trains_.size()) return 0;
+openlcb::NodeID AllTrainNodes::get_train_node_id(size_t id) {
+  if (id >= trains_.size()) return 0;
   if (trains_[id]->node_) {
     return trains_[id]->node_->node_id();
   }
@@ -187,7 +187,7 @@ class AllTrainNodes::TrainSnipHandler
     : public openlcb::IncomingMessageStateFlow {
  public:
   TrainSnipHandler(AllTrainNodes* parent, openlcb::SimpleInfoFlow* info_flow)
-      : IncomingMessageStateFlow(parent->tractionService_->iface()),
+      : IncomingMessageStateFlow(parent->train_service()->iface()),
         parent_(parent),
         responseFlow_(info_flow) {
     iface()->dispatcher()->register_handler(
@@ -252,7 +252,7 @@ class AllTrainNodes::TrainPipHandler
     : public openlcb::IncomingMessageStateFlow {
  public:
   TrainPipHandler(AllTrainNodes* parent)
-      : IncomingMessageStateFlow(parent->tractionService_->iface()),
+      : IncomingMessageStateFlow(parent->train_service()->iface()),
         parent_(parent) {
     iface()->dispatcher()->register_handler(
         this, openlcb::Defs::MTI_PROTOCOL_SUPPORT_INQUIRY,
@@ -470,8 +470,7 @@ AllTrainNodes::AllTrainNodes(TrainDb* db,
                              openlcb::TrainService* traction_service,
                              openlcb::SimpleInfoFlow* info_flow,
                              openlcb::MemoryConfigHandler* memory_config)
-    : db_(db),
-      tractionService_(traction_service),
+    : AllTrainNodesInterface(traction_service), db_(db),
       memoryConfigService_(memory_config),
       snipHandler_(new TrainSnipHandler(this, info_flow)),
       pipHandler_(new TrainPipHandler(this)) {
@@ -606,7 +605,7 @@ AllTrainNodes::Impl* AllTrainNodes::create_impl(int train_id, DccMode mode,
   if (impl->train_) {
     trains_.push_back(impl);
     impl->node_ =
-        new openlcb::TrainNodeForProxy(tractionService_, impl->train_);
+        new openlcb::TrainNodeForProxy(train_service(), impl->train_);
     impl->eventHandler_ =
         new openlcb::FixedEventProducer<openlcb::TractionDefs::IS_TRAIN_EVENT>(
             impl->node_);
@@ -617,7 +616,7 @@ AllTrainNodes::Impl* AllTrainNodes::create_impl(int train_id, DccMode mode,
   }
 }
 
-openlcb::NodeID AllTrainNodes::allocate_node(DccMode drive_type, int address) {
+openlcb::NodeID AllTrainNodes::allocate_node(DccMode drive_type, unsigned address) {
   Impl* impl = create_impl(-1, drive_type, address);
   if (!impl) return 0; // failed.
   impl->id = db_->add_dynamic_entry(new DccTrainDbEntry(address, drive_type));

--- a/cs/commandstation/AllTrainNodes.cxx
+++ b/cs/commandstation/AllTrainNodes.cxx
@@ -470,7 +470,8 @@ AllTrainNodes::AllTrainNodes(TrainDb* db,
                              openlcb::TrainService* traction_service,
                              openlcb::SimpleInfoFlow* info_flow,
                              openlcb::MemoryConfigHandler* memory_config)
-    : AllTrainNodesInterface(traction_service), db_(db),
+    : AllTrainNodesInterface(traction_service),
+      db_(db),
       memoryConfigService_(memory_config),
       snipHandler_(new TrainSnipHandler(this, info_flow)),
       pipHandler_(new TrainPipHandler(this)) {
@@ -604,8 +605,7 @@ AllTrainNodes::Impl* AllTrainNodes::create_impl(int train_id, DccMode mode,
 #endif  
   if (impl->train_) {
     trains_.push_back(impl);
-    impl->node_ =
-        new openlcb::TrainNodeForProxy(train_service(), impl->train_);
+    impl->node_ = new openlcb::TrainNodeForProxy(train_service(), impl->train_);
     impl->eventHandler_ =
         new openlcb::FixedEventProducer<openlcb::TractionDefs::IS_TRAIN_EVENT>(
             impl->node_);
@@ -616,7 +616,8 @@ AllTrainNodes::Impl* AllTrainNodes::create_impl(int train_id, DccMode mode,
   }
 }
 
-openlcb::NodeID AllTrainNodes::allocate_node(DccMode drive_type, unsigned address) {
+openlcb::NodeID AllTrainNodes::allocate_node(DccMode drive_type,
+                                             unsigned address) {
   Impl* impl = create_impl(-1, drive_type, address);
   if (!impl) return 0; // failed.
   impl->id = db_->add_dynamic_entry(new DccTrainDbEntry(address, drive_type));

--- a/cs/commandstation/AllTrainNodes.cxxtest
+++ b/cs/commandstation/AllTrainNodes.cxxtest
@@ -39,11 +39,6 @@
 
 namespace commandstation {
 
-// These components of the command station are needed in order to instantiate
-// real dcc train impl objects.
-DccPacketSink g_hardware;
-UpdateProcessor g_update_processor{&g_service, &g_hardware};
-
 TEST_F(AllTrainNodesTest, CreateDestroy) {}
 
 TEST_F(AllTrainNodesTest, PIPRequest) {

--- a/cs/commandstation/AllTrainNodes.hxx
+++ b/cs/commandstation/AllTrainNodes.hxx
@@ -38,9 +38,9 @@
 #include <memory>
 #include <vector>
 
-#include "openlcb/SimpleInfoProtocol.hxx"
-#include "commandstation/TrainDb.hxx"
 #include "commandstation/AllTrainNodesInterface.hxx"
+#include "commandstation/TrainDb.hxx"
+#include "openlcb/SimpleInfoProtocol.hxx"
 
 namespace openlcb {
 class Node;

--- a/cs/commandstation/AllTrainNodes.hxx
+++ b/cs/commandstation/AllTrainNodes.hxx
@@ -40,6 +40,7 @@
 
 #include "openlcb/SimpleInfoProtocol.hxx"
 #include "commandstation/TrainDb.hxx"
+#include "commandstation/AllTrainNodesInterface.hxx"
 
 namespace openlcb {
 class Node;
@@ -51,7 +52,7 @@ class MemoryConfigHandler;
 namespace commandstation {
 class FindProtocolServer;
 
-class AllTrainNodes {
+class AllTrainNodes : public AllTrainNodesInterface {
  public:
   AllTrainNodes(TrainDb* db, openlcb::TrainService* traction_service,
                 openlcb::SimpleInfoFlow* info_flow,
@@ -62,18 +63,18 @@ class AllTrainNodes {
   openlcb::TrainImpl* get_train_impl(int id);
 
   /// Returns a traindb entry or nullptr if the id is too high.
-  std::shared_ptr<TrainDbEntry> get_traindb_entry(int id);
+  std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t id) override;
 
   /// Returns a node id or 0 if the id is not known to be a train.
-  openlcb::NodeID get_train_node_id(int id);
+  openlcb::NodeID get_train_node_id(size_t id) override;
 
   /// Creates a new train node based on the given address and drive mode.
   /// @param drive_type describes what kind of train node this should be
   /// @param address is the hardware (legacy) address
   /// @return 0 if the allocation fails (invalid arguments)
-  openlcb::NodeID allocate_node(DccMode drive_type, int address);
+  openlcb::NodeID allocate_node(DccMode drive_type, unsigned address) override;
 
-  size_t size() { return trains_.size(); }
+  size_t size() override { return trains_.size(); }
 
   // For testing.
   bool find_flow_is_idle();
@@ -98,7 +99,6 @@ class AllTrainNodes {
 
   // Externally owned.
   TrainDb* db_;
-  openlcb::TrainService* tractionService_;
   openlcb::MemoryConfigHandler* memoryConfigService_;
 
   /// All train nodes that we know about.

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -36,8 +36,8 @@
 #ifndef _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
 #define _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
 
-#include "openlcb/Defs.hxx"
 #include "commandstation/TrainDbDefs.hxx"
+#include "openlcb/Defs.hxx"
 
 namespace openlcb {
 class TrainService;
@@ -79,7 +79,7 @@ class AllTrainNodesInterface {
   /// mode).
   /// @return the openlcb train node ID, or 0 if the arguments are not valid.
   virtual openlcb::NodeID allocate_node(DccMode mode, unsigned address) = 0;
-  
+
  protected:
   /// Pointer to the traction service instance. Externally owned.
   openlcb::TrainService* trainService_;

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -1,0 +1,90 @@
+/** \copyright
+ * Copyright (c) 2014-2016, Balazs Racz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are  permitted provided that the following conditions are met:
+ *
+ *  - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  - Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \file AllTrainNodesInterface.hxx
+ *
+ * Abstract class for the AllTrainNodes that prevents pulling in transitive
+ * dependencies.
+ *
+ * @author Balazs Racz
+ * @date 18 Feb 2016
+ */
+
+#ifndef _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
+#define _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
+
+#include "openlcb/Defs.hxx"
+#include "commandstation/TrainDbDefs.hxx"
+
+namespace openlcb {
+class TrainService;
+}
+
+namespace commandstation {
+
+/// Abstract class for the AllTrainNodes that prevents pulling in transitive
+/// dependencies.
+class AllTrainNodesInterface {
+ public:
+  /// Constructor.
+  /// @param service points to the traction service. Externally owned
+  /// (ownership is not taken).
+  AllTrainNodesInterface(openlcb::TrainService* service)
+      : trainService_(service) {}
+
+  /// @return the traction service instance.
+  openlcb::TrainService* train_service() { return trainService_; }
+
+  /// @return maximum (or current) number of trains managed by this
+  /// service. Trains are indexed 0..size().
+  virtual size_t size() = 0;
+
+  /// @return the train database entry for a given train index, or nullptr if
+  /// the train index is not valid.
+  /// @param index 0..size() - 1.
+  virtual std::shared_ptr<commandstation::TrainDbEntry> get_traindb_entry(
+      size_t index) = 0;
+
+  /// @return the openlcb train node ID for a given train index, or 0 if
+  /// the train index is not valid.
+  /// @param index 0..size() - 1.
+  virtual openlcb::NodeID get_train_node_id(size_t index) = 0;
+
+  /// Allocates a new legacy train node.
+  /// @param mode which protocol mode to use.
+  /// @param address legacy address (to be interpreted for the given protocol
+  /// mode).
+  /// @return the openlcb train node ID, or 0 if the arguments are not valid.
+  virtual openlcb::NodeID allocate_node(DccMode mode, unsigned address) = 0;
+  
+ protected:
+  /// Pointer to the traction service instance. Externally owned.
+  openlcb::TrainService* trainService_;
+};
+
+}  // namespace commandstation
+
+#endif  // FINDPROTOCOLSERVER

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -36,6 +36,8 @@
 #ifndef _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
 #define _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
 
+#include <memory>
+
 #include "commandstation/TrainDbDefs.hxx"
 #include "openlcb/Defs.hxx"
 

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -40,6 +40,7 @@
 
 #include "commandstation/TrainDbDefs.hxx"
 #include "openlcb/Defs.hxx"
+#include "utils/Destructable.hxx"
 
 namespace openlcb {
 class TrainService;
@@ -50,7 +51,7 @@ class TrainDbEntry;
 
 /// Abstract class for the AllTrainNodes that prevents pulling in transitive
 /// dependencies.
-class AllTrainNodesInterface {
+class AllTrainNodesInterface : public Destructable {
  public:
   /// Constructor.
   /// @param service points to the traction service. Externally owned

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -1,5 +1,5 @@
 /** \copyright
- * Copyright (c) 2014-2016, Balazs Racz
+ * Copyright (c) 2020, Balazs Racz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@
  * dependencies.
  *
  * @author Balazs Racz
- * @date 18 Feb 2016
+ * @date 8 Aug 2020
  */
 
 #ifndef _COMMANDSTATION_ALLTRAINNODESINTERFACE_HXX_
@@ -44,6 +44,7 @@ class TrainService;
 }
 
 namespace commandstation {
+class TrainDbEntry;
 
 /// Abstract class for the AllTrainNodes that prevents pulling in transitive
 /// dependencies.
@@ -65,8 +66,7 @@ class AllTrainNodesInterface {
   /// @return the train database entry for a given train index, or nullptr if
   /// the train index is not valid.
   /// @param index 0..size() - 1.
-  virtual std::shared_ptr<commandstation::TrainDbEntry> get_traindb_entry(
-      size_t index) = 0;
+  virtual std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t index) = 0;
 
   /// @return the openlcb train node ID for a given train index, or 0 if
   /// the train index is not valid.

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -83,6 +83,12 @@ class AllTrainNodesInterface : public Destructable {
   /// @return the openlcb train node ID, or 0 if the arguments are not valid.
   virtual openlcb::NodeID allocate_node(DccMode mode, unsigned address) = 0;
 
+#ifdef GTEST
+  /// @return true if the locomotive find flow has completed processing all
+  /// past requests.
+  virtual bool find_flow_is_idle() = 0;
+#endif  
+  
  protected:
   /// Pointer to the traction service instance. Externally owned.
   openlcb::TrainService* trainService_;

--- a/cs/commandstation/FindProtocolServer.cxxtest
+++ b/cs/commandstation/FindProtocolServer.cxxtest
@@ -21,11 +21,6 @@ static openlcb::EventId create_query(uint64_t nibbles, uint8_t settings) {
 }
 
 
-// These components of the command station are needed in order to instantiate
-// real dcc train impl objects.
-DccPacketSink g_hardware;
-UpdateProcessor g_update_processor{&g_service, &g_hardware};
-
 class FindProtocolTest : public AllTrainNodesTest {
  protected:
   ~FindProtocolTest() { wait(); }

--- a/cs/commandstation/FindProtocolServer.hxx
+++ b/cs/commandstation/FindProtocolServer.hxx
@@ -35,8 +35,8 @@
 #ifndef _COMMANDSTATION_FINDPROTOCOLSERVER_HXX_
 #define _COMMANDSTATION_FINDPROTOCOLSERVER_HXX_
 
-#include "commandstation/FindProtocolDefs.hxx"
 #include "commandstation/AllTrainNodesInterface.hxx"
+#include "commandstation/FindProtocolDefs.hxx"
 #include "openlcb/EventHandlerTemplates.hxx"
 #include "openlcb/TractionTrain.hxx"
 
@@ -61,9 +61,8 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
 
     if (event && event->dst_node) {
       // Identify addressed
-      if (!service()->is_known_train_node(event->dst_node))
-      {
-          return;
+      if (!service()->is_known_train_node(event->dst_node)) {
+        return;
       }
       static_assert(((FindProtocolDefs::TRAIN_FIND_BASE >>
                       FindProtocolDefs::TRAIN_FIND_MASK) &
@@ -155,24 +154,21 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
           parent_->pendingGlobalIdentify_ = false;
           return again();
         }
-        return allocate_and_call(
-            iface()->global_message_write_flow(),
-            STATE(send_response));
+        return allocate_and_call(iface()->global_message_write_flow(),
+                                 STATE(send_response));
       }
       auto db_entry = nodes()->get_traindb_entry(nextTrainId_);
       if (!db_entry) return call_immediately(STATE(next_iterate));
       if (FindProtocolDefs::match_query_to_node(eventId_, db_entry.get())) {
         hasMatches_ = true;
-        return allocate_and_call(
-            iface()->global_message_write_flow(),
-            STATE(send_response));
+        return allocate_and_call(iface()->global_message_write_flow(),
+                                 STATE(send_response));
       }
       return yield_and_call(STATE(next_iterate));
     }
 
     Action send_response() {
-      auto *b = get_allocation_result(
-          iface()->global_message_write_flow());
+      auto *b = get_allocation_result(iface()->global_message_write_flow());
       b->set_done(bn_.reset(this));
       if (eventId_ == REQUEST_GLOBAL_IDENTIFY) {
         b->data()->reset(
@@ -185,9 +181,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
                          openlcb::eventid_to_buffer(eventId_));
       }
       b->data()->set_flag_dst(openlcb::GenMessage::WAIT_FOR_LOCAL_LOOPBACK);
-      iface()
-          ->global_message_write_flow()
-          ->send(b);
+      iface()->global_message_write_flow()->send(b);
 
       return wait_and_call(STATE(next_iterate));
     }
@@ -218,8 +212,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
     /// Yields until the new node is initiaqlized and we are allowed to send
     /// traffic out from it.
     Action wait_for_new_node() {
-      openlcb::Node *n =
-          iface()->lookup_local_node(newNodeId_);
+      openlcb::Node *n = iface()->lookup_local_node(newNodeId_);
       HASSERT(n);
       if (n->is_initialized()) {
         return call_immediately(STATE(new_node_reply));
@@ -229,14 +222,12 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
     }
 
     Action new_node_reply() {
-      return allocate_and_call(
-          iface()->global_message_write_flow(),
-          STATE(send_new_node_response));
+      return allocate_and_call(iface()->global_message_write_flow(),
+                               STATE(send_new_node_response));
     }
 
     Action send_new_node_response() {
-      auto *b = get_allocation_result(
-          iface()->global_message_write_flow());
+      auto *b = get_allocation_result(iface()->global_message_write_flow());
       b->data()->reset(openlcb::Defs::MTI_PRODUCER_IDENTIFIED_VALID, newNodeId_,
                        openlcb::eventid_to_buffer(eventId_));
       iface()->global_message_write_flow()->send(b);
@@ -247,7 +238,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
     AllTrainNodesInterface *nodes() { return parent_->nodes(); }
 
     openlcb::If *iface() { return parent_->iface(); }
-    
+
     openlcb::EventId eventId_;
     union {
       unsigned nextTrainId_;
@@ -270,7 +261,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
   AllTrainNodesInterface *nodes() { return nodes_; }
 
   /// Pointer to the AllTrainNodes instance. Externally owned.
-  AllTrainNodesInterface* nodes_;
+  AllTrainNodesInterface *nodes_;
   /// Set to true when a global identify message is received. When a global
   /// identify starts processing, it shall be set to false. If a global
   /// identify request arrives with no pendingGlobalIdentify_, that is a

--- a/cs/commandstation/FindProtocolServer.hxx
+++ b/cs/commandstation/FindProtocolServer.hxx
@@ -36,7 +36,7 @@
 #define _COMMANDSTATION_FINDPROTOCOLSERVER_HXX_
 
 #include "commandstation/FindProtocolDefs.hxx"
-#include "commandstation/AllTrainNodes.hxx"
+#include "commandstation/AllTrainNodesInterface.hxx"
 #include "openlcb/EventHandlerTemplates.hxx"
 #include "openlcb/TractionTrain.hxx"
 
@@ -44,7 +44,7 @@ namespace commandstation {
 
 class FindProtocolServer : public openlcb::SimpleEventHandler {
  public:
-  FindProtocolServer(AllTrainNodes *nodes) : parent_(nodes) {
+  FindProtocolServer(AllTrainNodesInterface *nodes) : nodes_(nodes) {
     openlcb::EventRegistry::instance()->register_handler(
         EventRegistryEntry(this, FindProtocolDefs::TRAIN_FIND_BASE),
         FindProtocolDefs::TRAIN_FIND_MASK);
@@ -61,8 +61,10 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
 
     if (event && event->dst_node) {
       // Identify addressed
-      auto *impl = parent_->find_node(event->dst_node);
-      if (!impl) return;
+      if (!service()->is_known_train_node(event->dst_node))
+      {
+          return;
+      }
       static_assert(((FindProtocolDefs::TRAIN_FIND_BASE >>
                       FindProtocolDefs::TRAIN_FIND_MASK) &
                      1) == 1,
@@ -125,7 +127,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
   class FindProtocolFlow : public StateFlow<Buffer<Request>, QList<1> > {
    public:
     FindProtocolFlow(FindProtocolServer *parent)
-        : StateFlow(parent->parent_->tractionService_), parent_(parent) {}
+        : StateFlow(parent->service()), parent_(parent) {}
 
     Action entry() override {
       eventId_ = message()->data()->event_;
@@ -154,7 +156,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
           return again();
         }
         return allocate_and_call(
-            nodes()->tractionService_->iface()->global_message_write_flow(),
+            iface()->global_message_write_flow(),
             STATE(send_response));
       }
       auto db_entry = nodes()->get_traindb_entry(nextTrainId_);
@@ -162,7 +164,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
       if (FindProtocolDefs::match_query_to_node(eventId_, db_entry.get())) {
         hasMatches_ = true;
         return allocate_and_call(
-            nodes()->tractionService_->iface()->global_message_write_flow(),
+            iface()->global_message_write_flow(),
             STATE(send_response));
       }
       return yield_and_call(STATE(next_iterate));
@@ -170,7 +172,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
 
     Action send_response() {
       auto *b = get_allocation_result(
-          nodes()->tractionService_->iface()->global_message_write_flow());
+          iface()->global_message_write_flow());
       b->set_done(bn_.reset(this));
       if (eventId_ == REQUEST_GLOBAL_IDENTIFY) {
         b->data()->reset(
@@ -183,7 +185,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
                          openlcb::eventid_to_buffer(eventId_));
       }
       b->data()->set_flag_dst(openlcb::GenMessage::WAIT_FOR_LOCAL_LOOPBACK);
-      parent_->parent_->tractionService_->iface()
+      iface()
           ->global_message_write_flow()
           ->send(b);
 
@@ -217,7 +219,7 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
     /// traffic out from it.
     Action wait_for_new_node() {
       openlcb::Node *n =
-          nodes()->tractionService_->iface()->lookup_local_node(newNodeId_);
+          iface()->lookup_local_node(newNodeId_);
       HASSERT(n);
       if (n->is_initialized()) {
         return call_immediately(STATE(new_node_reply));
@@ -228,24 +230,24 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
 
     Action new_node_reply() {
       return allocate_and_call(
-          nodes()->tractionService_->iface()->global_message_write_flow(),
+          iface()->global_message_write_flow(),
           STATE(send_new_node_response));
     }
 
     Action send_new_node_response() {
       auto *b = get_allocation_result(
-          nodes()->tractionService_->iface()->global_message_write_flow());
+          iface()->global_message_write_flow());
       b->data()->reset(openlcb::Defs::MTI_PRODUCER_IDENTIFIED_VALID, newNodeId_,
                        openlcb::eventid_to_buffer(eventId_));
-      parent_->parent_->tractionService_->iface()
-          ->global_message_write_flow()
-          ->send(b);
+      iface()->global_message_write_flow()->send(b);
       return exit();
     }
 
    private:
-    AllTrainNodes *nodes() { return parent_->parent_; }
+    AllTrainNodesInterface *nodes() { return parent_->nodes(); }
 
+    openlcb::If *iface() { return parent_->iface(); }
+    
     openlcb::EventId eventId_;
     union {
       unsigned nextTrainId_;
@@ -257,8 +259,18 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
     StateFlowTimer timer_{this};
   };
 
-  AllTrainNodes *parent_;
+  /// @return the openlcb interface to which the train nodes (and the traction
+  /// service) are bound.
+  openlcb::If *iface() { return service()->iface(); }
 
+  /// @return the openlcb Traction Service.
+  openlcb::TrainService *service() { return nodes()->train_service(); }
+
+  /// @return the AllTrainNodes instance.
+  AllTrainNodesInterface *nodes() { return nodes_; }
+
+  /// Pointer to the AllTrainNodes instance. Externally owned.
+  AllTrainNodesInterface* nodes_;
   /// Set to true when a global identify message is received. When a global
   /// identify starts processing, it shall be set to false. If a global
   /// identify request arrives with no pendingGlobalIdentify_, that is a

--- a/cs/commandstation/UpdateProcessor.hxx
+++ b/cs/commandstation/UpdateProcessor.hxx
@@ -34,6 +34,9 @@
  * @date 13 May 2014
  */
 
+#ifndef _COMMANDSTATION_UPDATEPROCESSOR_HXX_
+#define _COMMANDSTATION_UPDATEPROCESSOR_HXX_
+
 #include <vector>
 #include <algorithm>
 
@@ -161,3 +164,5 @@ class UpdateProcessor : public StateFlow<Buffer<dcc::Packet>, QList<1> >,
 };
 
 }  // namespace commandstation
+
+#endif // _COMMANDSTATION_UPDATEPROCESSOR_HXX_

--- a/cs/commandstation/cm_test_helper.hxx
+++ b/cs/commandstation/cm_test_helper.hxx
@@ -19,8 +19,11 @@ extern Pool* const g_incoming_datagram_allocator = init_main_buffer_pool();
 
 namespace commandstation {
 
+/// Fake track interface. Receives DCC packets from the packet update loop, and
+/// drops them on the floor.
 class DccPacketSink : public dcc::PacketFlowInterface {
  public:
+  /// Virtual entry point for receiving the next packet.
   void send(Buffer<dcc::Packet>* b, unsigned prio) {
     b->unref();
   }

--- a/cs/commandstation/cm_test_helper.hxx
+++ b/cs/commandstation/cm_test_helper.hxx
@@ -1,7 +1,7 @@
 #include "commandstation/AllTrainNodes.hxx"
+#include "commandstation/UpdateProcessor.hxx"
 #include "commandstation/TrainDb.hxx"
 #include "utils/async_traction_test_helper.hxx"
-
 #include "openlcb/SimpleInfoProtocol.hxx"
 #include "openlcb/SimpleNodeInfoMockUserFile.hxx"
 #include "openlcb/ConfigUpdateFlow.hxx"
@@ -18,6 +18,18 @@ extern Pool* const g_incoming_datagram_allocator = init_main_buffer_pool();
 }
 
 namespace commandstation {
+
+class DccPacketSink : public dcc::PacketFlowInterface {
+ public:
+  void send(Buffer<dcc::Packet>* b, unsigned prio) {
+    b->unref();
+  }
+};
+
+// These components of the command station are needed in order to instantiate
+// real dcc train impl objects.
+DccPacketSink g_hardware;
+UpdateProcessor g_update_processor{&g_service, &g_hardware};
 
 const struct const_traindb_entry_t const_lokdb[] = {
     // 0
@@ -49,13 +61,6 @@ const struct const_traindb_entry_t const_lokdb[] = {
 
 extern const size_t const_lokdb_size =
     sizeof(const_lokdb) / sizeof(const_lokdb[0]);
-
-class DccPacketSink : public dcc::PacketFlowInterface {
- public:
-  void send(Buffer<dcc::Packet>* b, unsigned prio) {
-    b->unref();
-  }
-};
 
 extern const char TRAINCDI_DATA[] = "Test cdi data";
 extern const size_t TRAINCDI_SIZE = sizeof(TRAINCDI_DATA);
@@ -109,7 +114,7 @@ class AllTrainNodesTestBase : public openlcb::TractionTest {
   openlcb::CanDatagramService datagramService_{ifCan_.get(), 5, 2};
   openlcb::MemoryConfigHandler memoryConfigHandler_{&datagramService_, nullptr,
                                                     5};
-  std::unique_ptr<AllTrainNodes> trainNodes_;
+  std::unique_ptr<AllTrainNodesInterface> trainNodes_;
 };
 
 class AllTrainNodesTest : public AllTrainNodesTestBase {


### PR DESCRIPTION
- Adds AllTrainNodesInterface which abstracts away the functionality for AllTrainNodes with respect to the FindProtocolServer.
- switches the train DB identifiers from int to size_t in the interface
Minor fixes:
- Changes to the test infrastructure: refactores common objects into the _test_helper.hxx file.
- Adds missing include guards to UpdateProcessor.hxx