### PR TITLE
Makes the get_traindb_entry function on AllTrainNodes operate in async.

### DIFF
--- a/cs/commandstation/AllTrainNodes.cxx
+++ b/cs/commandstation/AllTrainNodes.cxx
@@ -168,7 +168,9 @@ AllTrainNodes::Impl* AllTrainNodes::find_node(openlcb::NodeID node_id) {
 }
 
 /// Returns a traindb entry or nullptr if the id is too high.
-std::shared_ptr<TrainDbEntry> AllTrainNodes::get_traindb_entry(size_t id) {
+std::shared_ptr<TrainDbEntry> AllTrainNodes::get_traindb_entry(
+    size_t id, Notifiable* done) {
+  done->notify();
   return db_->get_entry(id);
 }
 
@@ -205,7 +207,7 @@ class AllTrainNodes::TrainSnipHandler
 
   Action send_response_request() {
     auto* b = get_allocation_result(responseFlow_);
-    auto entry = parent_->get_traindb_entry(impl_->id);
+    auto entry = parent_->db_->get_entry(impl_->id);
     if (entry.get()) {
       snipName_ = entry->get_train_name();
     } else {
@@ -345,7 +347,7 @@ class AllTrainNodes::TrainFDISpace : public openlcb::MemorySpace {
 
  private:
   void reset_file() {
-    auto e = parent_->get_traindb_entry(impl_->id);
+    auto e = parent_->db_->get_entry(impl_->id);
     e->start_read_functions();
     gen_.reset(std::move(e));
   }

--- a/cs/commandstation/AllTrainNodes.cxxtest
+++ b/cs/commandstation/AllTrainNodes.cxxtest
@@ -54,8 +54,8 @@ TEST_F(AllTrainNodesTest, CreateNode) {
   send_packet_and_expect_response(":X19828123N0443;",
                                   ":X19668443N0123D41E00000000;");
   wait();
-  auto* db_entry = trainNodes_->get_traindb_entry(3).get();
-  ASSERT_TRUE(db_entry);
+  auto db_entry = get_traindb_entry(3);
+  ASSERT_TRUE((bool)db_entry);
   EXPECT_EQ(183, db_entry->get_legacy_address());
   EXPECT_EQ(string("183"), db_entry->get_train_name());
 }
@@ -67,8 +67,8 @@ TEST_F(AllTrainNodesTest, CreateNodeShort) {
   send_packet_and_expect_response(":X19828123N0443;",
                                   ":X19668443N0123D41E00000000;");
   wait();
-  auto* db_entry = trainNodes_->get_traindb_entry(3).get();
-  ASSERT_TRUE(db_entry);
+  auto db_entry = get_traindb_entry(3);
+  ASSERT_TRUE((bool)db_entry);
   EXPECT_EQ(18, db_entry->get_legacy_address());
   EXPECT_EQ(string("18S"), db_entry->get_train_name());
 }
@@ -80,8 +80,8 @@ TEST_F(AllTrainNodesTest, CreateNodeLong) {
   send_packet_and_expect_response(":X19828123N0443;",
                                   ":X19668443N0123D41E00000000;");
   wait();
-  auto* db_entry = trainNodes_->get_traindb_entry(3).get();
-  ASSERT_TRUE(db_entry);
+  auto db_entry = get_traindb_entry(3);
+  ASSERT_TRUE((bool)db_entry);
   EXPECT_EQ(18, db_entry->get_legacy_address());
   EXPECT_EQ(string("018L"), db_entry->get_train_name());
 }
@@ -93,8 +93,8 @@ TEST_F(AllTrainNodesTest, CreateNodeMarklin) {
   send_packet_and_expect_response(":X19828123N0443;",
                                   ":X19668443N0123D41E00000000;");
   wait();
-  auto* db_entry = trainNodes_->get_traindb_entry(3).get();
-  ASSERT_TRUE(db_entry);
+  auto db_entry = get_traindb_entry(3);
+  ASSERT_TRUE((bool)db_entry);
   EXPECT_EQ(13, db_entry->get_legacy_address());
   EXPECT_EQ(string("13M"), db_entry->get_train_name());
 }
@@ -144,7 +144,7 @@ TEST_F(StoredTrainNodesTest, create_with_train_search_7) {
   expect_train_start(0x443, 53, dcc::TrainAddressType::DCC_SHORT_ADDRESS);
   start();
 
-  auto db_entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto db_entry = get_traindb_entry(trainNodes_->size() - 1);
   
   clear_expect(true); // strict
   expect_packet(":X19544443N090099FFFFFFF700;");
@@ -170,7 +170,7 @@ TEST_F(StoredTrainNodesTest, create_with_train_search_7) {
       FindProtocolDefs::match_query_to_node(0x090099FFFFFFF7C0, db_entry.get()));
 
   
-  db_entry = trainNodes_->get_traindb_entry(0);
+  db_entry = get_traindb_entry(0);
 
   EXPECT_EQ("Am 843 093-6", db_entry->get_train_name());
   EXPECT_EQ(43, db_entry->get_legacy_address());
@@ -193,7 +193,7 @@ TEST_F(StoredTrainNodesTest, create_with_train_search_7_alt) {
   expect_train_start(0x443, 53, dcc::TrainAddressType::DCC_SHORT_ADDRESS);
   start();
 
-  auto db_entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto db_entry = get_traindb_entry(trainNodes_->size() - 1);
   
   clear_expect(true); // strict
   expect_packet(":X19544443N090099FFFFFFF700;");
@@ -219,7 +219,7 @@ TEST_F(StoredTrainNodesTest, create_with_train_search_7_alt) {
       FindProtocolDefs::match_query_to_node(0x090099FFFFFFF7C0, db_entry.get()));
 
   
-  db_entry = trainNodes_->get_traindb_entry(0);
+  db_entry = get_traindb_entry(0);
 
   EXPECT_EQ("Am 843 093-6", db_entry->get_train_name());
   EXPECT_EQ(43, db_entry->get_legacy_address());

--- a/cs/commandstation/AllTrainNodes.hxx
+++ b/cs/commandstation/AllTrainNodes.hxx
@@ -63,7 +63,8 @@ class AllTrainNodes : public AllTrainNodesInterface {
   openlcb::TrainImpl* get_train_impl(int id);
 
   /// Returns a traindb entry or nullptr if the id is too high.
-  std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t id) override;
+  std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t id,
+                                                  Notifiable* done) override;
 
   /// Returns a node id or 0 if the id is not known to be a train.
   openlcb::NodeID get_train_node_id(size_t id) override;

--- a/cs/commandstation/AllTrainNodesInterface.hxx
+++ b/cs/commandstation/AllTrainNodesInterface.hxx
@@ -42,6 +42,8 @@
 #include "openlcb/Defs.hxx"
 #include "utils/Destructable.hxx"
 
+class Notifiable;
+
 namespace openlcb {
 class TrainService;
 }
@@ -66,10 +68,17 @@ class AllTrainNodesInterface : public Destructable {
   /// service. Trains are indexed 0..size().
   virtual size_t size() = 0;
 
+  /// Looks up a train DB entry by train index. This is an asynchronous call:
+  /// If the information is readily available, then done will be notified
+  /// inline. If the information is not available, the caller has to wait until
+  /// done is notified, then repeat the call to retrieve the result.
   /// @return the train database entry for a given train index, or nullptr if
-  /// the train index is not valid.
+  /// the train index is not valid or the information is not available yet.
   /// @param index 0..size() - 1.
-  virtual std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t index) = 0;
+  /// @param done will be notified exactly once, either inline (if the answer
+  /// is ready) or out of line (if it is not).
+  virtual std::shared_ptr<TrainDbEntry> get_traindb_entry(size_t index,
+                                                          Notifiable* done) = 0;
 
   /// @return the openlcb train node ID for a given train index, or 0 if
   /// the train index is not valid.

--- a/cs/commandstation/FindProtocolServer.cxxtest
+++ b/cs/commandstation/FindProtocolServer.cxxtest
@@ -147,7 +147,7 @@ TEST_F(FindProtocolTest, WithAllocate) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(DCC_128, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("23S", entry->get_train_name());
@@ -171,7 +171,7 @@ TEST_F(FindProtocolTest, WithAllocateDefault28) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(DCC_28, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("23S", entry->get_train_name());
@@ -196,7 +196,7 @@ TEST_F(FindProtocolTest, WithAllocateShort6) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 6.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(DCC_128, entry->get_legacy_drive_mode());
   EXPECT_EQ(6, entry->get_legacy_address());
   EXPECT_EQ("6S", entry->get_train_name());
@@ -220,7 +220,7 @@ TEST_F(FindProtocolTest, WithAllocateDefaultMarklin) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(MARKLIN_NEW, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("23M", entry->get_train_name());
@@ -240,7 +240,7 @@ TEST_F(FindProtocolTest, AllocateMarklin) {
   wait();
   clear_expect();
   // Checks that the new train is indeed marklin with address 23.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(MARKLIN_NEW, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("23M", entry->get_train_name());
@@ -263,7 +263,7 @@ TEST_F(FindProtocolTest, AllocateLongAddressViaBit) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23 long.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(DCC_128_LONG_ADDRESS, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("023L", entry->get_train_name());
@@ -283,7 +283,7 @@ TEST_F(FindProtocolTest, AllocateLongAddressViaPrefixZero) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23 long.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(DCC_128_LONG_ADDRESS, entry->get_legacy_drive_mode());
   EXPECT_EQ(23, entry->get_legacy_address());
   EXPECT_EQ("023L", entry->get_train_name());
@@ -303,7 +303,7 @@ TEST_F(FindProtocolTest, AllocateLongAddressDefault) {
   wait();
   clear_expect();
   // Checks that the new train is indeed DCC with address 23 long.
-  auto entry = trainNodes_->get_traindb_entry(trainNodes_->size() - 1);
+  auto entry = get_traindb_entry(trainNodes_->size() - 1);
   EXPECT_EQ(323, entry->get_legacy_address());
   EXPECT_EQ("323", entry->get_train_name());
 }

--- a/cs/commandstation/FindProtocolServer.hxx
+++ b/cs/commandstation/FindProtocolServer.hxx
@@ -192,7 +192,22 @@ class FindProtocolServer : public openlcb::SimpleEventHandler {
         return allocate_and_call(iface()->global_message_write_flow(),
                                  STATE(send_response));
       }
-      auto db_entry = nodes()->get_traindb_entry(nextTrainId_);
+      return call_immediately(STATE(try_traindb_lookup));
+    }
+
+    /// This state attempts to look up the entry in the train database, and
+    /// performs asynchronous waits and re-tries according to the contract of
+    /// AllTrainNodesInterface.
+    Action try_traindb_lookup() {
+      bn_.reset(this);
+      bn_.new_child();
+      auto db_entry = nodes()->get_traindb_entry(nextTrainId_, &bn_);
+      if (!bn_.abort_if_almost_done()) {
+        bn_.notify();
+        // Repeats this state after the notification arrives.
+        return wait();
+      }
+      // Call completed inline.
       if (!db_entry) return call_immediately(STATE(next_iterate));
       if (FindProtocolDefs::match_query_to_node(eventId_, db_entry.get())) {
         hasMatches_ = true;

--- a/cs/commandstation/FindTrainNode.cxxtest
+++ b/cs/commandstation/FindTrainNode.cxxtest
@@ -63,7 +63,7 @@ class FindTrainNodeTest : public TrainDbTest {
 
 TEST_F(FindTrainNodeTest, CreateDestroy) { wait(); }
 
-TEST_F(FindTrainNodeTest, FindLocalTrain) { 
+TEST_F(FindTrainNodeTest, DISABLED_FindLocalTrain) { 
   wait();
   auto b = invoke_flow(&findFlow_, (DccMode)0, 51);
 
@@ -71,7 +71,7 @@ TEST_F(FindTrainNodeTest, FindLocalTrain) {
   EXPECT_EQ(0x060100000000u | 51u, b->data()->nodeId);
 }
 
-TEST_F(FindTrainNodeTest, FindLocalTrainLong) { 
+TEST_F(FindTrainNodeTest, DISABLED_FindLocalTrainLong) { 
   /// @todo (balazs.racz) remove FindTrainNode class and it's tests. These
   /// tests do no longer represent realistic usage of this class, but there are
   /// no production usage dependencies on it anyway. RemoteFindTrainFlow
@@ -82,7 +82,7 @@ TEST_F(FindTrainNodeTest, FindLocalTrainLong) {
   EXPECT_EQ(0x06010000C000u | 2u, b->data()->nodeId);
 }
 
-TEST_F(FindTrainNodeTest, FindLocalTrainLong2) { 
+TEST_F(FindTrainNodeTest, DISABLED_FindLocalTrainLong2) { 
   auto b = invoke_flow(&findFlow_, (DccMode) 0, 350);
 
   EXPECT_EQ(0, b->data()->resultCode);

--- a/cs/commandstation/FindTrainNode.hxx
+++ b/cs/commandstation/FindTrainNode.hxx
@@ -379,21 +379,7 @@ class FindTrainNode : public StateFlow<Buffer<FindTrainNodeRequest>, QList<1>> {
       remoteLookupFlow_(node) {}
 
  private:
-  Action entry() override { return call_immediately(STATE(try_find_in_db)); }
-
-  /** Looks through all nodes that exist in the train DB and tries to find one
-   * with the given legacy address. */
-  Action try_find_in_db() {
-    for (unsigned train_id = 0; train_id < allTrainNodes_->size(); ++train_id) {
-      auto e = allTrainNodes_->get_traindb_entry(train_id);
-      if (!e.get() || input()->address != e->get_legacy_address()) {
-        continue;
-      }
-      // TODO: check drive mode.
-      return return_ok(allTrainNodes_->get_train_node_id(train_id));
-    }
-    return call_immediately(STATE(try_find_on_openlcb));
-  }
+  Action entry() override { return call_immediately(STATE(try_find_on_openlcb)); }
 
   Action try_find_on_openlcb() {
     return invoke_subflow_and_wait(&remoteLookupFlow_, STATE(olcb_find_done),

--- a/cs/commandstation/cm_test_helper.hxx
+++ b/cs/commandstation/cm_test_helper.hxx
@@ -138,6 +138,13 @@ class AllTrainNodesTest : public AllTrainNodesTestBase {
 
   ~AllTrainNodesTest() { wait(); }
 
+  /// Lookup a TrainDB entry from the AllTrainNodes object.
+  /// @param id the train ID, 0.. train_nodes()->size() - 1.
+  /// @return the train DB entry or a nullptr if it is invalid.
+  std::shared_ptr<commandstation::TrainDbEntry> get_traindb_entry(int id) {
+    return trainDb_.get_entry(id);
+  }
+
   TrainDb trainDb_;
 };
 
@@ -167,6 +174,10 @@ class StoredTrainNodesTest : public AllTrainNodesTestBase {
   }
   
   ~StoredTrainNodesTest() { wait(); }
+
+  std::shared_ptr<commandstation::TrainDbEntry> get_traindb_entry(int id) {
+    return trainDb_.get_entry(id);
+  }
 
   TrainDbConfig cfg_{0};
   TrainDb trainDb_{cfg_};


### PR DESCRIPTION
- Updates all implementations and most uses.

- Removes the implementation of FindTrainNode to look into the local database.
  This class is scheduled to be removed altogether.