### PR TITLE
Fix railcom board firmware.

### DIFF
--- a/cs/targets/railcom/main.cxx
+++ b/cs/targets/railcom/main.cxx
@@ -415,7 +415,7 @@ class WatchForDccSignal : public StateFlowBase {
  * @return 0, should never return
  */
 int appl_main(int argc, char* argv[]) {
-  LOG(VERBOSE, "hello world");
+  LOG(ALWAYS, "hello world");
   
   LED_BLUE_Pin::set(false);
   stack.check_version_and_factory_reset(cfg.seg().internal(), openlcb::EXPECTED_VERSION);

--- a/cs/targets/railcom/main.cxx
+++ b/cs/targets/railcom/main.cxx
@@ -481,6 +481,8 @@ int appl_main(int argc, char* argv[]) {
   dcc_test_thread.start("dcc_printer", 0, 2048);
 #endif  
 
+  DCC_IN_Pin::set_hw();
+
   // Uncomment this line to print all railcom packets to the LCC bus using a
   // non-standard message. This is a lot of traffic, so only useful for
   // debugging.


### PR DESCRIPTION
Critical fixes:
- Adds missing component that caused the output ports to never be enabled.
- Changes the port initialization order, because the railcom port must be opened before the DCC port.
- Re-initializes the DCC input pin after opening all devices.

Additional improvements:
- Adds an optional component to print all DCC packets in text to the USB port.
- Adds comment about the railcom debug proxy object.
- Optionalizes the CPU-load  display.
- Adds a LED that shows whether we detect DCC signal.