### PR TITLE
Up the deadline to 3 seconds for train search and allocate.

### DIFF
--- a/cs/commandstation/FindTrainNode.hxx
+++ b/cs/commandstation/FindTrainNode.hxx
@@ -78,7 +78,7 @@ struct RemoteFindTrainNodeRequest {
     nodeId = 0;
     if (FindProtocolDefs::is_find_event(event_id) &&
         (event_id & FindProtocolDefs::ALLOCATE)) {
-      resultCode = TIMEOUT_SPECIFIED | 800;
+      resultCode = TIMEOUT_SPECIFIED | 3000;
     }
     resultCallback = std::move(res);
   }


### PR DESCRIPTION
Previous deadline was 0.8 seconds and caused unnecessary error code 1030.