### PR TITLE
Updates the computation of the railcom broadcast event ID ranges.

### DIFF
--- a/cs/commandstation/RailcomBroadcastFlow.hxx
+++ b/cs/commandstation/RailcomBroadcastFlow.hxx
@@ -147,11 +147,12 @@ class RailcomBroadcastFlow : public dcc::RailcomHubPort {
   Action finish() { return exit(); }
 
  private:
-  static constexpr uint64_t FEEDBACK_EVENTID_BASE =
-      (0x09ULL << 56) | openlcb::TractionDefs::NODE_ID_DCC;
+  static constexpr uint64_t FEEDBACK_EVENTID_BASE = (0x0680ULL << 48);
   uint64_t address_to_eventid(unsigned channel, uint16_t address) {
     uint64_t ret = FEEDBACK_EVENTID_BASE;
-    ret |= uint64_t(channel & 0xff) << 48;
+    ret |= ((node_->node_id() >> 24) & 0x0FFFULL) << 40;
+    ret |= (node_->node_id() & 0xFFFFF) << 20;
+    ret |= uint64_t(channel & 0xf) << 16;
     ret |= address;
     return ret;
   }


### PR DESCRIPTION
This moves the broadcast event IDs into the standard range (according to new draft as of 2023-03).