### PR TITLE
Increase the number of program track startup reset packets

### DIFF
--- a/cs/commandstation/ProgrammingTrackFrontend.hxx
+++ b/cs/commandstation/ProgrammingTrackFrontend.hxx
@@ -293,7 +293,7 @@ class ProgrammingTrackFrontend
     // When we have always-on program track, these initial resets are sent out
     // only once. Later operations are started immediately.
     return invoke_subflow_and_wait(backend_, STATE(enter_service_mode_done),
-                                   ProgrammingTrackRequest::SEND_RESET, 25);
+                                   ProgrammingTrackRequest::SEND_RESET, 85);
   }
 
   Action enter_service_mode_done() {


### PR DESCRIPTION
Some decoders that have a lot of onboard capacitance, and are very close to the program track steady state current limits, can experience an increase in current following an ack. This can result sometimes result in a current fault being detected.

Increasing the number of reset packets when the program track starts provides a bit more time for the onboard capacitance to charge up ahead of the first ack. This provides a bit of extra discharge capacity when the ack comes, preventing the expected uptick in charging current following the ack from triggering a current fault.